### PR TITLE
CSS fix for full-screen maps in Safari

### DIFF
--- a/app/assets/stylesheets/geoportal/_show.scss
+++ b/app/assets/stylesheets/geoportal/_show.scss
@@ -1,8 +1,3 @@
-#document [data-map="item"] {
-  min-height: 440px;
-  height: inherit !important;
-}
-
 // Transparent Gray CSS Background Spinner
 #viewer-container.well {
   background-color: #ddd;


### PR DESCRIPTION
Removing these CSS rules to fix full-screen maps in Safari. Might impact how "static image" types are displayed in the application, but resolves this issue.

Fixes #457 

### Bug
![css_fullscreen_bug](https://user-images.githubusercontent.com/69827/166288256-a71ae71e-ed79-404f-9424-bb6dfb1cb8c0.gif)

### Fix
![css_fullscreen_fix](https://user-images.githubusercontent.com/69827/166288327-3d35df34-2c83-4e44-9cd5-128ad1deae63.gif)

