### PR TITLE
JS: fix customized viewer initialization error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'noticed'
 gem 'paper_trail'
 
 # Image migration
-gem 'geoblacklight_sidecar_images', git: "https://github.com/geoblacklight/geoblacklight_sidecar_images.git", branch: "feature/statesman-update"
+gem 'geoblacklight_sidecar_images', git: "https://github.com/geoblacklight/geoblacklight_sidecar_images.git", branch: "develop"
 gem 'mini_magick', '~> 4.9.4'
 gem "image_processing", ">= 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,17 +27,17 @@ GIT
 
 GIT
   remote: https://github.com/geoblacklight/geoblacklight_sidecar_images.git
-  revision: 089e2a4a677a5d522b9d88fef0ef46cfa69961a0
-  branch: feature/statesman-update
+  revision: ca23e5ef8eb4fa90d5c9cb955943deeb0dcba6f5
+  branch: develop
   specs:
-    geoblacklight_sidecar_images (1.0.0)
+    geoblacklight_sidecar_images (1.1.0)
       faraday (>= 2.0)
       geoblacklight (~> 4.0)
       image_processing (~> 1.6)
       mimemagic (~> 0.3)
       mini_magick (~> 4.9.4)
-      rails (>= 5.2, < 7.1)
-      statesman (~> 10.0.0)
+      rails (>= 5.2, < 8.0)
+      statesman (>= 3.4)
 
 GIT
   remote: https://github.com/geobtaa/geoblacklight_admin.git

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -40,6 +40,7 @@
 //= require geoblacklight/viewers/viewer
 //= require ./geoportal/viewers/map
 //= require ./geoportal/viewers/b1g_image
+//= require ./geoportal/viewers/cog
 //= require ./geoportal/viewers/download
 //= require ./geoportal/viewers/esri
 //= require ./geoportal/viewers/esri/dynamic_map_layer
@@ -50,10 +51,10 @@
 //= require ./geoportal/viewers/iiif_manifest
 //= require ./geoportal/viewers/index_map
 //= require geoblacklight/viewers/oembed
-
-//= require ./geoportal/viewers/wms
+//= require ./geoportal/viewers/pmtiles
 //= require ./geoportal/viewers/tilejson
 //= require ./geoportal/viewers/tms
+//= require ./geoportal/viewers/wms
 //= require ./geoportal/viewers/wmts
 //= require ./geoportal/viewers/xyz
 

--- a/app/assets/javascripts/geoportal/viewers/cog.js
+++ b/app/assets/javascripts/geoportal/viewers/cog.js
@@ -1,0 +1,5 @@
+//= require geoblacklight/viewers/viewer
+
+GeoBlacklight.Viewer.Cog = GeoBlacklight.Viewer.extend({
+  load: function() {}
+});

--- a/app/assets/javascripts/geoportal/viewers/iiif.js
+++ b/app/assets/javascripts/geoportal/viewers/iiif.js
@@ -1,0 +1,25 @@
+//= require geoblacklight/viewers/viewer
+
+GeoBlacklight.Viewer.Iiif = GeoBlacklight.Viewer.extend({
+  load: function() {
+    this.adjustLayout();
+
+    this.map = L.map(this.element, {
+      center: [0, 0],
+      crs: L.CRS.Simple,
+      zoom: 0
+    });
+    this.loadControls();
+    this.iiifLayer = L.tileLayer.iiif(this.data.url)
+      .addTo(this.map);
+  },
+
+  adjustLayout: function() {
+
+    // hide attribute table
+    $('#table-container').hide();
+
+    // expand viewer element
+    $(this.element).parent().attr('class', 'col-md-12');
+  }
+});

--- a/app/assets/javascripts/geoportal/viewers/oembed.js
+++ b/app/assets/javascripts/geoportal/viewers/oembed.js
@@ -1,0 +1,13 @@
+//= require geoblacklight/viewers/viewer
+
+GeoBlacklight.Viewer.Oembed = GeoBlacklight.Viewer.extend({
+  load: function() {
+    var $el = $(this.element);
+    $.getJSON(this.data.url, function(data){
+      if (data === null){
+        return;
+      }
+      $el.html(data.html);
+    });
+  },
+});

--- a/app/assets/javascripts/geoportal/viewers/pmtiles.js
+++ b/app/assets/javascripts/geoportal/viewers/pmtiles.js
@@ -1,0 +1,5 @@
+//= require geoblacklight/viewers/viewer
+
+GeoBlacklight.Viewer.Pmtiles = GeoBlacklight.Viewer.extend({
+  load: function() {}
+});


### PR DESCRIPTION
Adds a local copy of each GBL v4 viewer to the Geoportal. Resolves the JS error that stopped the application from getting to the relationships initialization. Bumps the GBLSCI gem to latest, which makes GH CI run green.

Fixes #623

![Map-illustrating-the-journey-of-the-Pundit-Nain-Singh-through-Great-Tibet-from-Ladákh-to-Assam-cartographic-material-to-accompany-the-paper-by-Captn-H-Trotter-R-E-engraved-by-Edwd-Weller-geotiff-Big-Ten-Academic-Alliance-Geoportal-11-04-2](https://github.com/user-attachments/assets/50848414-6e37-45ad-bd4f-351bcfcbb43f)
