### PR TITLE
Add: Conference Banner

### DIFF
--- a/app/assets/stylesheets/geoportal/_banner.scss
+++ b/app/assets/stylesheets/geoportal/_banner.scss
@@ -1,0 +1,14 @@
+#banner {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  z-index: 3000;
+  box-shadow: 0 -4px 6px rgba(0, 0, 0, 0.1);
+  border-top: 1px solid #856504;
+
+  .alert {
+    margin-bottom: 0;
+    text-align: center;
+    border-radius: 0;
+  }
+}

--- a/app/assets/stylesheets/geoportal/_footer.scss
+++ b/app/assets/stylesheets/geoportal/_footer.scss
@@ -13,7 +13,7 @@ $visited-color: lighten($link-color, 20%);
 
 section#footer-app {
   color:$white;
-  padding-bottom:1rem;
+  padding-bottom:4rem;
   background-color: $btaa-blue;
   border-top: 1rem solid $btaa-blue-dark;
   border-bottom: 0.5rem solid $btaa-blue-dark;

--- a/app/assets/stylesheets/geoportal/geoportal.scss
+++ b/app/assets/stylesheets/geoportal/geoportal.scss
@@ -1,6 +1,7 @@
 @import 'variables';
 @import 'icons';
 @import 'advanced';
+@import 'banner';
 @import 'code';
 @import 'navbar';
 @import 'results';

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -71,6 +71,9 @@
       <section id="footer-app" aria-label='Application Footer'>
         <%= render :partial => 'shared/footer_app' %>
       </section>
+      <section id="banner" aria-label="Banner">
+        <%= render :partial => 'shared/banner' %>
+      </section>
     <% end %>
 
     <%= render partial: 'shared/modal' %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,0 +1,11 @@
+<div class="alert alert-warning" role="alert">
+  <p class="mb-0">
+    <span class="blacklight-icons blacklight-icon-lightbulb-solid">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+        <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+        <path fill="#856504" d="M480 32c0-12.9-7.8-24.6-19.8-29.6s-25.7-2.2-34.9 6.9L381.7 53c-48 48-113.1 75-181 75l-8.7 0-32 0-96 0c-35.3 0-64 28.7-64 64l0 96c0 35.3 28.7 64 64 64l0 128c0 17.7 14.3 32 32 32l64 0c17.7 0 32-14.3 32-32l0-128 8.7 0c67.9 0 133 27 181 75l43.6 43.6c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-147.6c18.6-8.8 32-32.5 32-60.4s-13.4-51.6-32-60.4L480 32zm-64 76.7L416 240l0 131.3C357.2 317.8 280.5 288 200.7 288l-8.7 0 0-96 8.7 0c79.8 0 156.5-29.8 215.3-83.3z"/>
+      </svg>
+    </span>
+    <strong>Call for Proposals!</strong> <a target="_blank" href="https://gin.btaa.org/conference/2025/">Submit your GIS research & maps</a> for the Big Ten GIS event 4/11/25!
+  </p>
+</div>


### PR DESCRIPTION
Adds a persistent bottom-most banner to advertise our upcoming Big Ten GIS conference.
![Screenshot 2025-02-14 at 9 00 07 AM](https://github.com/user-attachments/assets/d388ed24-46be-42a5-a1a6-f3b907ebfa5f)

Fixes #646