### PR TITLE
Locales: Remove the word "Original" from download links

### DIFF
--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -9,7 +9,7 @@ en:
       web_service: Web service copied to clipboard
     download:
       download: 'Download'
-      download_link: 'Original %{download_format}'
+      download_link: '%{download_format}'
       success: 'Your file %{title} is ready for download'
       hgl_success: 'You should receive an email when your download is ready.'
       hgl_request: 'Request Layer'

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -42,8 +42,8 @@ class ShowPageTest < ApplicationSystemTestCase
 
     # Downloads
     assert page.has_content?("Downloads")
-    assert page.has_link?("Original Tiff")
-    assert page.has_link?("Original JPG")
+    assert page.has_link?("Tiff")
+    assert page.has_link?("JPG")
 
     # Provenance
     assert page.has_content?("Minnesota")
@@ -68,7 +68,7 @@ class ShowPageTest < ApplicationSystemTestCase
     # Download
     assert page.has_content?("Download")
     click_on("Download")
-    assert page.has_link?("Original Shapefile")
+    assert page.has_link?("Shapefile")
 
     # Export
     assert page.has_link?("Open in ArcGIS")
@@ -93,7 +93,7 @@ class ShowPageTest < ApplicationSystemTestCase
     # Download
     assert page.has_content?("Download")
     click_on("Download")
-    assert page.has_link?("Original Shapefile")
+    assert page.has_link?("Shapefile")
 
     # Provenance
     assert page.has_link?("Minnesota")
@@ -158,7 +158,7 @@ class ShowPageTest < ApplicationSystemTestCase
     # Download
     assert page.has_content?("Download")
     click_on("Download")
-    assert page.has_link?("Original GeoTIFF")
+    assert page.has_link?("GeoTIFF")
 
     # Data Relations
     # assert page.has_content?("Related Items")


### PR DESCRIPTION
### Before

![Screenshot 2025-02-14 at 9 29 51 AM](https://github.com/user-attachments/assets/42eea8ea-0aba-42f6-9b9f-447cf59f4de8)

### After

![Screenshot 2025-02-14 at 9 30 14 AM](https://github.com/user-attachments/assets/765a720a-9b60-4532-b2f7-19fd5eca705c)

Fixes #640