### PR TITLE
GeoRef facets: Divorce the Georeferenced and Allmaps facets

### DIFF
--- a/lib/tasks/geoportal.rake
+++ b/lib/tasks/geoportal.rake
@@ -161,7 +161,6 @@ namespace :geoportal do
             cleaned_doc = doc.except!(*keys_for_deletion)
 
             # 4. Add georeferenced value
-            cleaned_doc["gbl_georeferenced_b"] = true
             cleaned_doc["b1g_georeferenced_allmaps_b"] = true
 
             # 5. Re-index the georeferenced documents


### PR DESCRIPTION
Stop setting Aardvark's Georeferenced boolean flag to true for Allmaps'd items. Will require a full reindexing of Solr, and a re-run of the geoportal:allmaps:georeferenced_facet to finalize the divorce.

Fixes #637