### PR TITLE
Fix Kithe bridge callback registration

### DIFF
--- a/config/initializers/kithe_bridge_change_capture.rb
+++ b/config/initializers/kithe_bridge_change_capture.rb
@@ -13,6 +13,16 @@
 module KitheBridgeChangeCapture
   module_function
 
+  def attach_callbacks!
+    attach_document_deletion_callback!("Document".safe_constantize)
+    attach_parent_touch_callback!("DocumentDataDictionary".safe_constantize) do
+      document
+    end
+    attach_parent_touch_callback!("DocumentDataDictionaryEntry".safe_constantize) do
+      document_data_dictionary&.document
+    end
+  end
+
   def touch_parent_document!(document)
     return if document.nil?
 
@@ -52,42 +62,44 @@ module KitheBridgeChangeCapture
       unique_by: :index_kithe_bridge_deletions_on_friendlier_id
     )
   end
-end
 
-if defined?(Document)
-  Document.class_eval do
-    after_commit :kithe_bridge_capture_document_deletion, on: :destroy
+  def attach_document_deletion_callback!(klass)
+    return if klass.nil?
 
-    private
+    klass.class_eval do
+      unless _commit_callbacks.any? { |callback| callback.filter == :kithe_bridge_capture_document_deletion }
+        after_commit :kithe_bridge_capture_document_deletion, on: :destroy
+      end
 
-    def kithe_bridge_capture_document_deletion
-      KitheBridgeChangeCapture.capture_document_deletion!(self)
+      private
+
+      def kithe_bridge_capture_document_deletion
+        KitheBridgeChangeCapture.capture_document_deletion!(self)
+      end
+    end
+  end
+
+  def attach_parent_touch_callback!(klass, &document_resolver)
+    return if klass.nil?
+
+    klass.class_eval do
+      unless _save_callbacks.any? { |callback| callback.filter == :kithe_bridge_touch_parent_document }
+        after_save :kithe_bridge_touch_parent_document
+      end
+
+      unless _destroy_callbacks.any? { |callback| callback.filter == :kithe_bridge_touch_parent_document }
+        after_destroy :kithe_bridge_touch_parent_document
+      end
+
+      define_method(:kithe_bridge_touch_parent_document) do
+        KitheBridgeChangeCapture.touch_parent_document!(instance_exec(&document_resolver))
+      end
+
+      private :kithe_bridge_touch_parent_document
     end
   end
 end
 
-if defined?(DocumentDataDictionary)
-  DocumentDataDictionary.class_eval do
-    after_save :kithe_bridge_touch_parent_document
-    after_destroy :kithe_bridge_touch_parent_document
-
-    private
-
-    def kithe_bridge_touch_parent_document
-      KitheBridgeChangeCapture.touch_parent_document!(document)
-    end
-  end
-end
-
-if defined?(DocumentDataDictionaryEntry)
-  DocumentDataDictionaryEntry.class_eval do
-    after_save :kithe_bridge_touch_parent_document
-    after_destroy :kithe_bridge_touch_parent_document
-
-    private
-
-    def kithe_bridge_touch_parent_document
-      KitheBridgeChangeCapture.touch_parent_document!(document_data_dictionary&.document)
-    end
-  end
+Rails.application.config.to_prepare do
+  KitheBridgeChangeCapture.attach_callbacks!
 end

--- a/test/indexers/document_indexer_test.rb
+++ b/test/indexers/document_indexer_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DocumentIndexerTest < ActiveSupport::TestCase
+  SourceRecord = Struct.new(:friendlier_id, :id, :geomg_id_s, :publication_state)
+
+  test "includes document identifiers in traject record inspection" do
+    source_record = SourceRecord.new(
+      "rails-friendly-id",
+      "8d90e212-0f1a-49e0-a0f2-6c8fb7f2a9e2",
+      "solr-geomg-id",
+      "published"
+    )
+
+    context = Traject::Indexer::Context.new(
+      source_record: source_record,
+      source_record_id_proc: DocumentIndexer.new.source_record_id_proc,
+      output_hash: {"id" => "solr-output-id"}
+    )
+
+    record_inspect = context.record_inspect
+
+    assert_includes record_inspect, "source_id:Document.friendlier_id=rails-friendly-id"
+    assert_includes record_inspect, "Document.id=8d90e212-0f1a-49e0-a0f2-6c8fb7f2a9e2"
+    assert_includes record_inspect, "geomg_id_s=solr-geomg-id"
+    assert_includes record_inspect, "publication_state=published"
+    assert_includes record_inspect, "output_id:solr-output-id"
+  end
+end

--- a/test/models/kithe_bridge_change_capture_test.rb
+++ b/test/models/kithe_bridge_change_capture_test.rb
@@ -70,7 +70,23 @@ class KitheBridgeChangeCaptureTest < ActiveSupport::TestCase
     refute called
   end
 
+  test "attaches bridge callbacks after model constants load" do
+    2.times { KitheBridgeChangeCapture.attach_callbacks! }
+
+    assert_equal 1, callback_count(Document._commit_callbacks, :kithe_bridge_capture_document_deletion)
+
+    assert_equal 1, callback_count(DocumentDataDictionary._save_callbacks, :kithe_bridge_touch_parent_document)
+    assert_equal 1, callback_count(DocumentDataDictionary._destroy_callbacks, :kithe_bridge_touch_parent_document)
+
+    assert_equal 1, callback_count(DocumentDataDictionaryEntry._save_callbacks, :kithe_bridge_touch_parent_document)
+    assert_equal 1, callback_count(DocumentDataDictionaryEntry._destroy_callbacks, :kithe_bridge_touch_parent_document)
+  end
+
   private
+
+  def callback_count(callbacks, filter)
+    callbacks.count { |callback| callback.filter == filter }
+  end
 
   def with_class_method_stub(klass, method_name, replacement)
     singleton = class << klass; self; end

--- a/vendor/gems/geoblacklight_admin/app/indexers/document_indexer.rb
+++ b/vendor/gems/geoblacklight_admin/app/indexers/document_indexer.rb
@@ -20,6 +20,19 @@
 # If the "elements" table exists, additional fields are indexed based on
 # the Element model's configuration.
 class DocumentIndexer < Kithe::Indexer
+  def source_record_id_proc
+    @source_record_id_proc ||= lambda do |source_record|
+      next unless source_record
+
+      [
+        "Document.friendlier_id=#{source_record.try(:friendlier_id).presence || "(blank)"}",
+        "Document.id=#{source_record.try(:id).presence || "(blank)"}",
+        "geomg_id_s=#{source_record.respond_to?(:geomg_id_s) ? source_record.geomg_id_s.presence || "(blank)" : "(unavailable)"}",
+        "publication_state=#{source_record.try(:publication_state).presence || "(blank)"}"
+      ].join(" ")
+    end
+  end
+
   # Formats date/datetime values for Solr date fields (ISO8601 with time component)
   # Handles Date, DateTime, Time, String values, and arrays that look like Time#to_a results
   def self.format_date_for_solr(value, field_name = nil)

--- a/vendor/gems/geoblacklight_admin/app/models/document/bbox_validator.rb
+++ b/vendor/gems/geoblacklight_admin/app/models/document/bbox_validator.rb
@@ -10,65 +10,68 @@ class Document
   # BboxValidator
   class BboxValidator < ActiveModel::Validator
     def validate(record)
-      # Assume true for empty values
-      valid_geom = true
+      bbox = record.send(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box])
 
-      # Sane for W,S,E,N?
-      unless record.send(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box]).nil?
-        proper_bounding_box(record,
-          valid_geom)
+      # Assume true for empty values
+      return true if bbox.blank?
+
+      proper_bounding_box(record, bbox)
+    end
+
+    def proper_bounding_box(record, bbox)
+      valid_geom = true
+      field = GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box]
+
+      # "W,S,E,N" to [W,S,E,N]
+      geom = bbox.split(",").map(&:strip)
+
+      if geom.empty?
+        valid_geom = true
+      elsif geom.size != 4
+        valid_geom = false
+        record.errors.add(field, "invalid W,S,E,N syntax")
+      elsif geom.any? { |val| val.count(".") >= 2 }
+        valid_geom = false
+        record.errors.add(field,
+          "invalid ENVELOPE(W,E,N,S) syntax - found multiple periods in a coordinate value.")
+      else
+        w, s, e, n = geom.map { |val| parse_coordinate(val) }
+
+        if [w, s, e, n].any?(&:nil?)
+          valid_geom = false
+          record.errors.add(field, "invalid W,S,E,N syntax")
+        elsif w < -180.0 || w > 180.0
+          valid_geom = false
+          record.errors.add(field, "invalid minX present")
+        elsif s < -90.0 || s > 90.0
+          valid_geom = false
+          record.errors.add(field, "invalid minY present")
+        elsif e < -180.0 || e > 180.0
+          valid_geom = false
+          record.errors.add(field, "invalid maxX present")
+        elsif n < -90.0 || n > 90.0
+          valid_geom = false
+          record.errors.add(field, "invalid maxY present")
+        elsif e <= w
+          valid_geom = false
+          record.errors.add(field, "maxX must be greater than minX")
+        # Solr - maxY must be >= minY
+        elsif s >= n
+          valid_geom = false
+          record.errors.add(field, "maxY must be >= minY")
+        end
       end
 
       valid_geom
     end
 
-    def proper_bounding_box(record, valid_geom)
-      # Min/Max
-      min_max = [-180.0, -90.0, 180.0, 90.0]
+    private
 
-      # "W,S,E,N" to [W,S,E,N]
-      unless record.send(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box]).split(",").nil?
-        geom = record.send(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box]).split(",")
-
-        if geom.empty?
-          valid_geom = true
-        elsif geom.size != 4
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "invalid W,S,E,N syntax")
-        # W
-        elsif geom[0].to_f < min_max[0]
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "invalid minX present")
-        # S
-        elsif geom[1].to_f < min_max[1]
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "invalid minY present")
-        # E
-        elsif geom[2].to_f > min_max[2]
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "invalid maX present")
-        # N
-        elsif geom[3].to_f > min_max[3]
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "invalid maxY present")
-        # Solr - maxY must be >= minY
-        elsif geom[1].to_f >= geom[3].to_f
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box], "maxY must be >= minY")
-        end
-
-        # Reject ENVELOPE(-118.00.0000,-88.00.0000,51.00.0000,42.00.0000
-        # - Double period float-ish things?
-        geom.each do |val|
-          next unless val.count(".") >= 2
-
-          valid_geom = false
-          record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:bounding_box],
-            "invalid ENVELOPE(W,E,N,S) syntax - found multiple periods in a coordinate value.")
-        end
-      end
-
-      valid_geom
+    def parse_coordinate(value)
+      coordinate = Float(value)
+      coordinate if coordinate.finite?
+    rescue ArgumentError, TypeError
+      nil
     end
   end
 end

--- a/vendor/gems/geoblacklight_admin/app/models/document/geom_validator.rb
+++ b/vendor/gems/geoblacklight_admin/app/models/document/geom_validator.rb
@@ -10,6 +10,9 @@ require "rgeo/wkrep/wkt_parser"
 class Document
   # GeomValidator
   class GeomValidator < ActiveModel::Validator
+    POLYGON_SOLR_ERROR = "Invalid polygon: all points are coplanar input, Solr will not index"
+    GEOMETRY_BOUNDS_ERROR = "Invalid geometry: coordinates must be within longitude and latitude bounds for Solr indexing"
+
     def validate(record)
       # Assume true for empty values
       valid_geom = true
@@ -35,6 +38,7 @@ class Document
       rescue => e
         valid_geom = false
         record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:geometry], "Invalid envelope: #{e}")
+        return valid_geom
       end
 
       unless valid_geom
@@ -47,33 +51,28 @@ class Document
 
     # Validates POLYGON and MULTIPOLYGON
     def proper_geom(record)
+      field = GeoblacklightAdmin::Schema.instance.solr_fields[:geometry]
       geom = record.send(GeoblacklightAdmin::Schema.instance.solr_fields[:geometry])
+
       begin
-        valid_geom = if RGeo::Cartesian::Factory.new.parse_wkt(geom)
-          true
-        else
-          false
-        end
+        parsed_geom = RGeo::Cartesian::Factory.new.parse_wkt(geom)
       rescue => e
-        valid_geom = false
-        record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:geometry], "Invalid geometry: #{e}")
+        record.errors.add(field, "Invalid geometry: #{e}")
+        return false
       end
 
-      # Guard against a whole world polygons
-      if geom == "POLYGON((-180 90, 180 90, 180 -90, -180 -90, -180 90))"
-        valid_geom = false
-        record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:geometry],
-          "Invalid polygon: all points are coplanar input, Solr will not index")
+      unless parsed_geom
+        record.errors.add(field, "Invalid geometry")
+        return false
       end
 
-      # Guard against coplanar points
-      if geom == "POLYGON((-180.0 90.0, 180.0 90.0, 180.0 -90.0, -180.0 -90.0, -180.0 90.0))"
-        valid_geom = false
-        record.errors.add(GeoblacklightAdmin::Schema.instance.solr_fields[:geometry],
-          "Invalid polygon: all points are coplanar input, Solr will not index")
+      solr_error = polygon_solr_error(parsed_geom)
+      if solr_error.present?
+        record.errors.add(field, solr_error)
+        return false
       end
 
-      valid_geom
+      true
     end
 
     def valid_envelope?(envelope)
@@ -81,40 +80,40 @@ class Document
       valid_envelope = true
       error_message = ""
 
-      # Min/Max - W,E,N,S
-      # ENVELOPE(-180,180,90,-90)
-      min_max = [-180.0, 180.0, 90.0, -90.0]
-      envelope = envelope.split(",")
-
-      # Reject ENVELOPE(-118.00.0000,-88.00.0000,51.00.0000,42.00.0000)
-      # - Double period float-ish things?
-      envelope.each do |val|
-        if val.count(".") >= 2
-          valid_envelope = false
-          error_message = "invalid ENVELOPE(W,E,N,S) syntax - found multiple periods in coordinate value(s)."
-        end
-      end
+      envelope = envelope.split(",").map(&:strip)
 
       # @TODO: Essentially duplicated logic from bbox_validator.rb, DRY it up
       if envelope.size != 4
         valid_envelope = false
         error_message = "invalid ENVELOPE(W,E,N,S) syntax"
+      # Reject ENVELOPE(-118.00.0000,-88.00.0000,51.00.0000,42.00.0000)
+      # - Double period float-ish things?
+      elsif envelope.any? { |val| val.count(".") >= 2 }
+        valid_envelope = false
+        error_message = "invalid ENVELOPE(W,E,N,S) syntax - found multiple periods in coordinate value(s)."
+      elsif envelope.map { |val| parse_coordinate(val) }.any?(&:nil?)
+        valid_envelope = false
+        error_message = "invalid ENVELOPE(W,E,N,S) syntax"
       # W
-      elsif envelope[0].to_f < min_max[0]
+      elsif envelope[0].to_f < -180.0 || envelope[0].to_f > 180.0
         valid_envelope = false
         error_message = "invalid minX present"
       # E
-      elsif envelope[1].to_f > min_max[1]
+      elsif envelope[1].to_f < -180.0 || envelope[1].to_f > 180.0
         valid_envelope = false
-        error_message = "invalid maX present"
+        error_message = "invalid maxX present"
       # N
-      elsif envelope[2].to_f > min_max[2]
+      elsif envelope[2].to_f < -90.0 || envelope[2].to_f > 90.0
         valid_envelope = false
         error_message = "invalid maxY present"
       # S
-      elsif envelope[3].to_f < min_max[3]
+      elsif envelope[3].to_f < -90.0 || envelope[3].to_f > 90.0
         valid_envelope = false
         error_message = "invalid minY present"
+      # Solr - maxX must be greater than minX
+      elsif envelope[1].to_f <= envelope[0].to_f
+        valid_envelope = false
+        error_message = "maxX must be greater than minX"
       # Solr - maxY must be >= minY
       elsif envelope[3].to_f >= envelope[2].to_f
         valid_envelope = false
@@ -122,6 +121,73 @@ class Document
       end
 
       [valid_envelope, error_message]
+    end
+
+    private
+
+    def polygon_solr_error(geom)
+      polygon_rings(geom).each do |ring|
+        points = ring_points(ring)
+
+        return GEOMETRY_BOUNDS_ERROR if points.any? { |x, y| out_of_bounds?(x, y) }
+        return POLYGON_SOLR_ERROR if degenerate_ring?(points) || solr_coplanar_span?(points)
+      end
+
+      nil
+    end
+
+    def polygon_rings(geom)
+      if RGeo::Feature::Polygon.check_type(geom)
+        rings_for_polygon(geom)
+      elsif RGeo::Feature::MultiPolygon.check_type(geom)
+        (0...geom.num_geometries).flat_map { |i| rings_for_polygon(geom.geometry_n(i)) }
+      else
+        []
+      end
+    end
+
+    def rings_for_polygon(polygon)
+      rings = [polygon.exterior_ring]
+      rings.concat((0...polygon.num_interior_rings).map { |i| polygon.interior_ring_n(i) })
+    end
+
+    def ring_points(ring)
+      (0...ring.num_points).map do |i|
+        point = ring.point_n(i)
+        [point.x.to_f, point.y.to_f]
+      end
+    end
+
+    def out_of_bounds?(x, y)
+      x < -180.0 || x > 180.0 || y < -90.0 || y > 90.0
+    end
+
+    def degenerate_ring?(points)
+      return true if points.size < 4
+      return true if points.map(&:first).uniq.size < 2
+      return true if points.map(&:last).uniq.size < 2
+
+      polygon_area(points).zero?
+    end
+
+    def solr_coplanar_span?(points)
+      xs = points.map(&:first)
+      ys = points.map(&:last)
+
+      (xs.max - xs.min) >= 180.0 || (ys.max - ys.min) >= 180.0
+    end
+
+    def polygon_area(points)
+      points.each_cons(2).sum do |(x1, y1), (x2, y2)|
+        (x1 * y2) - (x2 * y1)
+      end.abs / 2.0
+    end
+
+    def parse_coordinate(value)
+      coordinate = Float(value)
+      coordinate if coordinate.finite?
+    rescue ArgumentError, TypeError
+      nil
     end
   end
 end

--- a/vendor/gems/geoblacklight_admin/test/indexers/document_indexer_test.rb
+++ b/vendor/gems/geoblacklight_admin/test/indexers/document_indexer_test.rb
@@ -83,4 +83,15 @@ class DocumentIndexerTest < ActiveSupport::TestCase
     assert_equal output_hash[GeoblacklightAdmin::Schema.instance.solr_fields[:suppressed_record]], [false]
     assert_equal output_hash[GeoblacklightAdmin::Schema.instance.solr_fields[:child_record]], [false]
   end
+
+  test "includes rails document identifiers in traject record inspection" do
+    context = DocumentIndexer.new.process_record(@document)
+    record_inspect = context.record_inspect
+
+    assert_includes record_inspect, "source_id:Document.friendlier_id=#{@document.friendlier_id}"
+    assert_includes record_inspect, "Document.id=#{@document.id}"
+    assert_includes record_inspect, "geomg_id_s=#{@document.geomg_id_s}"
+    assert_includes record_inspect, "publication_state=#{@document.publication_state}"
+    assert_includes record_inspect, "output_id:#{@document.friendlier_id}"
+  end
 end

--- a/vendor/gems/geoblacklight_admin/test/models/document/bbox_validator_test.rb
+++ b/vendor/gems/geoblacklight_admin/test/models/document/bbox_validator_test.rb
@@ -1,0 +1,57 @@
+# test/models/document_bbox_validator_test.rb
+require "test_helper"
+
+class DocumentBboxValidatorTest < ActiveSupport::TestCase
+  def setup
+    @document = documents(:ag)
+  end
+
+  test "validates a proper W,S,E,N bbox" do
+    @document.dcat_bbox = "-96.6391,40.3754,-90.1401,43.5012"
+
+    validator = Document::BboxValidator.new
+    valid = validator.validate(@document)
+
+    assert valid, "Expected W,S,E,N bbox to be valid"
+  end
+
+  test "rejects bbox with max longitude below boundary" do
+    @document.dcat_bbox = "-98.0,47.733333,-971.0,48.5"
+
+    validator = Document::BboxValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected out-of-range max longitude to be invalid"
+    assert_includes @document.errors["dcat_bbox"].join, "invalid maxX present"
+  end
+
+  test "rejects zero-width bbox" do
+    @document.dcat_bbox = "11.077,60.790,11.077,60.791"
+
+    validator = Document::BboxValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected zero-width bbox to be invalid"
+    assert_includes @document.errors["dcat_bbox"].join, "maxX must be greater than minX"
+  end
+
+  test "rejects non-numeric bbox coordinates" do
+    @document.dcat_bbox = "-98.0,47.733333,nope,48.5"
+
+    validator = Document::BboxValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected non-numeric bbox to be invalid"
+    assert_includes @document.errors["dcat_bbox"].join, "invalid W,S,E,N syntax"
+  end
+
+  test "rejects non-finite bbox coordinates" do
+    @document.dcat_bbox = "-98.0,47.733333,NaN,48.5"
+
+    validator = Document::BboxValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected non-finite bbox to be invalid"
+    assert_includes @document.errors["dcat_bbox"].join, "invalid W,S,E,N syntax"
+  end
+end

--- a/vendor/gems/geoblacklight_admin/test/models/document/geom_validator_test.rb
+++ b/vendor/gems/geoblacklight_admin/test/models/document/geom_validator_test.rb
@@ -36,12 +36,22 @@ class DocumentGeomValidatorTest < ActiveSupport::TestCase
   end
 
   test "validates a proper MULTIPOLYGON" do
-    @document.locn_geometry = "MULTIPOLYGON(((-180 90, 180 90, 180 -90, -180 -90, -180 90)))"
+    @document.locn_geometry = "MULTIPOLYGON(((-80 25, -65 18, -64 33, -80 25)))"
 
     validator = Document::GeomValidator.new
     valid = validator.validate(@document)
 
     assert valid, "Expected MULTIPOLYGON to be valid"
+  end
+
+  test "rejects whole-world MULTIPOLYGON" do
+    @document.locn_geometry = "MULTIPOLYGON(((-180 90, 180 90, 180 -90, -180 -90, -180 90)))"
+
+    validator = Document::GeomValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected world-wide MULTIPOLYGON to be invalid"
+    assert_includes @document.errors["locn_geometry"].join, "Invalid polygon: all points are coplanar input, Solr will not index"
   end
 
   test "rejects invalid POLYGON" do
@@ -61,6 +71,26 @@ class DocumentGeomValidatorTest < ActiveSupport::TestCase
     valid = validator.validate(@document)
 
     assert_not valid, "Expected coplanar points to be rejected"
+    assert_includes @document.errors["locn_geometry"].join, "Invalid polygon: all points are coplanar input, Solr will not index"
+  end
+
+  test "rejects collapsed polygon from duplicate longitudes" do
+    @document.locn_geometry = "POLYGON((11.077 60.791, 11.077 60.791, 11.077 60.790, 11.077 60.790, 11.077 60.791))"
+
+    validator = Document::GeomValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected collapsed POLYGON to be rejected"
+    assert_match(/Invalid geometry|Invalid polygon/, @document.errors["locn_geometry"].join)
+  end
+
+  test "rejects polygon spanning 180 longitude degrees" do
+    @document.locn_geometry = "POLYGON((-177.000 45.027, 3.000 45.027, 3.000 -45.027, -177.000 -45.027, -177.000 45.027))"
+
+    validator = Document::GeomValidator.new
+    valid = validator.validate(@document)
+
+    assert_not valid, "Expected 180-degree longitude span POLYGON to be rejected"
     assert_includes @document.errors["locn_geometry"].join, "Invalid polygon: all points are coplanar input, Solr will not index"
   end
 end


### PR DESCRIPTION
## Summary

Fixes Kithe bridge callback registration, tightens `Document` spatial validations, and makes Traject/Solr reindex failures traceable back to `Document.friendlier_id` based on the production Solr reindex failures found on June 16, 2026.

## Root Cause

Production loaded `config/initializers/kithe_bridge_change_capture.rb` before `Document` was defined, so the `defined?(Document)` guard skipped callback registration. Hard-deleted documents were removed from Postgres, but no `kithe_bridge_deletions` tombstone was recorded for bridge syncs.

The Solr reindex also surfaced records that the database accepted but Solr rejected, mostly malformed or degenerate spatial values: collapsed polygons, whole-world/180-degree-span WKT polygons, and out-of-range bbox coordinates such as `-971.0` longitude.

A follow-up review of the failed reindex log showed that Traject only emitted the Solr `output_id` in `record_inspect`. When those IDs no longer matched current rows, the failure CSV had 68 `not_found` records and no direct way to map the error back to Rails `Document.friendlier_id` values.

## Changes

- Registers bridge callbacks inside `Rails.application.config.to_prepare`, using `safe_constantize` to load model constants when available.
- Makes callback registration idempotent so repeated `to_prepare` runs do not duplicate callbacks.
- Adds regression coverage that calls registration twice and verifies exactly one callback is attached for document deletion and related parent-touch callbacks.
- Tightens `Document::BboxValidator` parsing for `W,S,E,N` values, including non-numeric/non-finite values, out-of-bounds lon/lat values, and zero/reversed-width bboxes.
- Tightens `Document::GeomValidator` for Solr compatibility by rejecting collapsed polygon rings, out-of-bounds coordinates, and world/180-degree-span polygon and multipolygon shapes.
- Adds spatial validation regression coverage from the failed reindex examples.
- Adds Traject `source_record_id_proc` logging for `Document.friendlier_id`, database `Document.id`, `geomg_id_s`, and `publication_state` so future `Could not add record` errors include a stable Rails mapping.
- Adds host-app and vendored indexer coverage for the new Traject record inspection output.

## Validation

- `bin/rails test test/models/kithe_bridge_change_capture_test.rb`
- `bin/rails test test/indexers/document_indexer_test.rb`
- `ruby -c` on the updated validators and spatial validator tests
- Direct validator harness for production-style bad bbox, collapsed polygon, 180-degree-span polygon, whole-world multipolygon, valid whole-world ENVELOPE, and malformed ENVELOPE cases

Note: the vendored engine tests could not be run directly in this checkout because `vendor/gems/geoblacklight_admin/.internal_test_app` is not present. `standardrb` is also not available in the current bundle.