### PR TITLE
Export Bridge relationship inverses

### DIFF
--- a/db/migrate/20260617183000_update_kithe_to_resources_bridge_to_version6.rb
+++ b/db/migrate/20260617183000_update_kithe_to_resources_bridge_to_version6.rb
@@ -1,0 +1,15 @@
+class UpdateKitheToResourcesBridgeToVersion6 < ActiveRecord::Migration[7.2]
+  def up
+    update_view :kithe_to_resources_bridge,
+                version: 6,
+                revert_to_version: 5,
+                materialized: true
+  end
+
+  def down
+    update_view :kithe_to_resources_bridge,
+                version: 5,
+                revert_to_version: 6,
+                materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_10_111000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_17_183000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -667,319 +667,359 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_10_111000) do
   add_foreign_key "uri_transitions", "solr_document_uris"
 
   create_view "kithe_to_resources_bridge", materialized: true, sql_definition: <<-SQL
-      WITH live_documents AS (
-           SELECT COALESCE(kithe_models.friendlier_id, (kithe_models.id)::character varying) AS id,
-              kithe_models.title AS dct_title_s,
+      WITH live_document_ids AS (
+           SELECT kithe_models.id,
+              kithe_models.title,
+              kithe_models.type,
+              kithe_models."position",
+              kithe_models.json_attributes,
+              kithe_models.created_at,
+              kithe_models.updated_at,
+              kithe_models.parent_id,
+              kithe_models.friendlier_id,
+              kithe_models.file_data,
+              kithe_models.representative_id,
+              kithe_models.leaf_representative_id,
+              kithe_models.kithe_model_type,
+              kithe_models.import_id,
               kithe_models.publication_state,
-              (kithe_models.import_id)::character varying AS import_id,
+              COALESCE(kithe_models.friendlier_id, (kithe_models.id)::character varying) AS bridge_id
+             FROM kithe_models
+            WHERE ((kithe_models.type)::text = 'Document'::text)
+          ), relationship_values AS (
+           SELECT live_document_ids.bridge_id AS subject_id,
+              relation_fields.field_name,
+              btrim(related_ids.related_id) AS object_id
+             FROM ((live_document_ids
+               CROSS JOIN LATERAL ( VALUES ('dct_relation_sm'::text,(live_document_ids.json_attributes -> 'dct_relation_sm'::text)), ('pcdm_memberOf_sm'::text,(live_document_ids.json_attributes -> 'pcdm_memberOf_sm'::text)), ('dct_isPartOf_sm'::text,(live_document_ids.json_attributes -> 'dct_isPartOf_sm'::text)), ('dct_source_sm'::text,(live_document_ids.json_attributes -> 'dct_source_sm'::text)), ('dct_isVersionOf_sm'::text,(live_document_ids.json_attributes -> 'dct_isVersionOf_sm'::text)), ('dct_replaces_sm'::text,(live_document_ids.json_attributes -> 'dct_replaces_sm'::text)), ('dct_isReplacedBy_sm'::text,(live_document_ids.json_attributes -> 'dct_isReplacedBy_sm'::text))) relation_fields(field_name, raw_value))
+               CROSS JOIN LATERAL jsonb_array_elements_text(
+                  CASE
+                      WHEN ((relation_fields.raw_value IS NULL) OR (relation_fields.raw_value = 'null'::jsonb)) THEN '[]'::jsonb
+                      WHEN (jsonb_typeof(relation_fields.raw_value) = 'array'::text) THEN relation_fields.raw_value
+                      ELSE jsonb_build_array(relation_fields.raw_value)
+                  END) related_ids(related_id))
+            WHERE (btrim(related_ids.related_id) <> ''::text)
+          ), relationship_exports AS (
+           SELECT relationship_values.subject_id AS document_id,
+              relationship_values.field_name,
+              relationship_values.object_id AS related_id
+             FROM relationship_values
+          UNION
+           SELECT relationship_values.object_id AS document_id,
+              'dct_relation_sm'::text AS field_name,
+              relationship_values.subject_id AS related_id
+             FROM relationship_values
+            WHERE (relationship_values.field_name = 'dct_relation_sm'::text)
+          UNION
+           SELECT relationship_values.object_id AS document_id,
+              'dct_isReplacedBy_sm'::text AS field_name,
+              relationship_values.subject_id AS related_id
+             FROM relationship_values
+            WHERE (relationship_values.field_name = 'dct_replaces_sm'::text)
+          UNION
+           SELECT relationship_values.object_id AS document_id,
+              'dct_replaces_sm'::text AS field_name,
+              relationship_values.subject_id AS related_id
+             FROM relationship_values
+            WHERE (relationship_values.field_name = 'dct_isReplacedBy_sm'::text)
+          ), live_documents AS (
+           SELECT live_document_ids.bridge_id AS id,
+              live_document_ids.title AS dct_title_s,
+              live_document_ids.publication_state,
+              (live_document_ids.import_id)::character varying AS import_id,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_alternative_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_alternative_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_alternative_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_alternative_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_alternative_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_alternative_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_alternative_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_alternative_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_alternative_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_alternative_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_alternative_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_description_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_description_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_description_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_description_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_description_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_description_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_description_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_description_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_description_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_description_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_description_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_language_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_language_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_language_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_language_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_language_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_language_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_language_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_language_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_language_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_language_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_language_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'gbl_displayNote_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'gbl_displayNote_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_displayNote_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'gbl_displayNote_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'gbl_displayNote_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'gbl_displayNote_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'gbl_displayNote_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_displayNote_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'gbl_displayNote_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'gbl_displayNote_sm'::text))
                           END) AS jsonb_array_elements_text) AS "gbl_displayNote_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_creator_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_creator_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_creator_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_creator_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_creator_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_creator_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_creator_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_creator_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_creator_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_creator_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_creator_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_publisher_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_publisher_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_publisher_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_publisher_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_publisher_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_publisher_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_publisher_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_publisher_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_publisher_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_publisher_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_publisher_sm,
-              (kithe_models.json_attributes ->> 'schema_provider_s'::text) AS schema_provider_s,
+              (live_document_ids.json_attributes ->> 'schema_provider_s'::text) AS schema_provider_s,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'gbl_resourceClass_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'gbl_resourceClass_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_resourceClass_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'gbl_resourceClass_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'gbl_resourceClass_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'gbl_resourceClass_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'gbl_resourceClass_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_resourceClass_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'gbl_resourceClass_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'gbl_resourceClass_sm'::text))
                           END) AS jsonb_array_elements_text) AS "gbl_resourceClass_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'gbl_resourceType_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'gbl_resourceType_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_resourceType_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'gbl_resourceType_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'gbl_resourceType_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'gbl_resourceType_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'gbl_resourceType_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_resourceType_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'gbl_resourceType_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'gbl_resourceType_sm'::text))
                           END) AS jsonb_array_elements_text) AS "gbl_resourceType_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_subject_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_subject_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_subject_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_subject_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_subject_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_subject_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_subject_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_subject_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_subject_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_subject_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_subject_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dcat_theme_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dcat_theme_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dcat_theme_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dcat_theme_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dcat_theme_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dcat_theme_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dcat_theme_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dcat_theme_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dcat_theme_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dcat_theme_sm'::text))
                           END) AS jsonb_array_elements_text) AS dcat_theme_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dcat_keyword_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dcat_keyword_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dcat_keyword_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dcat_keyword_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dcat_keyword_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dcat_keyword_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dcat_keyword_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dcat_keyword_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dcat_keyword_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dcat_keyword_sm'::text))
                           END) AS jsonb_array_elements_text) AS dcat_keyword_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_temporal_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_temporal_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_temporal_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_temporal_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_temporal_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_temporal_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_temporal_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_temporal_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_temporal_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_temporal_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_temporal_sm,
-              (kithe_models.json_attributes ->> 'dct_issued_s'::text) AS dct_issued_s,
+              (live_document_ids.json_attributes ->> 'dct_issued_s'::text) AS dct_issued_s,
               ARRAY( SELECT (jsonb_array_elements_text(
                           CASE
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_indexYear_im'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'gbl_indexYear_im'::text)
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_indexYear_im'::text)) = 'string'::text) THEN jsonb_build_array((kithe_models.json_attributes -> 'gbl_indexYear_im'::text))
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_indexYear_im'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'gbl_indexYear_im'::text)
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_indexYear_im'::text)) = 'string'::text) THEN jsonb_build_array((live_document_ids.json_attributes -> 'gbl_indexYear_im'::text))
                               ELSE '[]'::jsonb
                           END))::integer AS jsonb_array_elements_text) AS "gbl_indexYear_im",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'gbl_dateRange_drsim'::text) IS NULL) OR ((kithe_models.json_attributes -> 'gbl_dateRange_drsim'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'gbl_dateRange_drsim'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'gbl_dateRange_drsim'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'gbl_dateRange_drsim'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'gbl_dateRange_drsim'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'gbl_dateRange_drsim'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'gbl_dateRange_drsim'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'gbl_dateRange_drsim'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'gbl_dateRange_drsim'::text))
                           END) AS jsonb_array_elements_text) AS "gbl_dateRange_drsim",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_spatial_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_spatial_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_spatial_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_spatial_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_spatial_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_spatial_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_spatial_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_spatial_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_spatial_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_spatial_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_spatial_sm,
-              (kithe_models.json_attributes ->> 'locn_geometry'::text) AS locn_geometry,
-              (kithe_models.json_attributes ->> 'dcat_bbox'::text) AS dcat_bbox,
-              (kithe_models.json_attributes ->> 'dcat_centroid'::text) AS dcat_centroid,
+              (live_document_ids.json_attributes ->> 'locn_geometry'::text) AS locn_geometry,
+              (live_document_ids.json_attributes ->> 'dcat_bbox'::text) AS dcat_bbox,
+              (live_document_ids.json_attributes ->> 'dcat_centroid'::text) AS dcat_centroid,
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_relation_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS dct_relation_sm,
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'pcdm_memberOf_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS "pcdm_memberOf_sm",
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isPartOf_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS "dct_isPartOf_sm",
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_source_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS dct_source_sm,
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isVersionOf_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS "dct_isVersionOf_sm",
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_replaces_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS dct_replaces_sm,
+              ARRAY( SELECT DISTINCT relationship_exports.related_id
+                     FROM relationship_exports
+                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isReplacedBy_sm'::text))
+                    ORDER BY relationship_exports.related_id) AS "dct_isReplacedBy_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_relation_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_relation_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_relation_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_relation_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_relation_sm'::text))
-                          END) AS jsonb_array_elements_text) AS dct_relation_sm,
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'pcdm_memberOf_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'pcdm_memberOf_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'pcdm_memberOf_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'pcdm_memberOf_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'pcdm_memberOf_sm'::text))
-                          END) AS jsonb_array_elements_text) AS "pcdm_memberOf_sm",
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_isPartOf_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_isPartOf_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_isPartOf_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_isPartOf_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_isPartOf_sm'::text))
-                          END) AS jsonb_array_elements_text) AS "dct_isPartOf_sm",
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_source_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_source_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_source_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_source_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_source_sm'::text))
-                          END) AS jsonb_array_elements_text) AS dct_source_sm,
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_isVersionOf_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_isVersionOf_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_isVersionOf_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_isVersionOf_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_isVersionOf_sm'::text))
-                          END) AS jsonb_array_elements_text) AS "dct_isVersionOf_sm",
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_replaces_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_replaces_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_replaces_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_replaces_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_replaces_sm'::text))
-                          END) AS jsonb_array_elements_text) AS dct_replaces_sm,
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_isReplacedBy_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_isReplacedBy_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_isReplacedBy_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_isReplacedBy_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_isReplacedBy_sm'::text))
-                          END) AS jsonb_array_elements_text) AS "dct_isReplacedBy_sm",
-              ARRAY( SELECT jsonb_array_elements_text(
-                          CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_rights_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_rights_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_rights_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_rights_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_rights_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_rights_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_rights_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_rights_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_rights_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_rights_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_rights_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_rightsHolder_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_rightsHolder_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_rightsHolder_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_rightsHolder_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_rightsHolder_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_rightsHolder_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_rightsHolder_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_rightsHolder_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_rightsHolder_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_rightsHolder_sm'::text))
                           END) AS jsonb_array_elements_text) AS "dct_rightsHolder_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_license_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_license_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_license_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_license_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_license_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_license_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_license_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_license_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_license_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_license_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_license_sm,
-              (kithe_models.json_attributes ->> 'dct_accessRights_s'::text) AS "dct_accessRights_s",
-              (kithe_models.json_attributes ->> 'dct_format_s'::text) AS dct_format_s,
-              (kithe_models.json_attributes ->> 'gbl_fileSize_s'::text) AS "gbl_fileSize_s",
-              (kithe_models.json_attributes ->> 'gbl_wxsIdentifier_s'::text) AS "gbl_wxsIdentifier_s",
-              (kithe_models.json_attributes ->> 'dct_references_s'::text) AS dct_references_s,
+              (live_document_ids.json_attributes ->> 'dct_accessRights_s'::text) AS "dct_accessRights_s",
+              (live_document_ids.json_attributes ->> 'dct_format_s'::text) AS dct_format_s,
+              (live_document_ids.json_attributes ->> 'gbl_fileSize_s'::text) AS "gbl_fileSize_s",
+              (live_document_ids.json_attributes ->> 'gbl_wxsIdentifier_s'::text) AS "gbl_wxsIdentifier_s",
+              (live_document_ids.json_attributes ->> 'dct_references_s'::text) AS dct_references_s,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'dct_identifier_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'dct_identifier_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'dct_identifier_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'dct_identifier_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'dct_identifier_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'dct_identifier_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_identifier_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'dct_identifier_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'dct_identifier_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'dct_identifier_sm'::text))
                           END) AS jsonb_array_elements_text) AS dct_identifier_sm,
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'gbl_mdModified_dt'::text), ''::text), 'null'::text))::timestamp without time zone AS "gbl_mdModified_dt",
-              (kithe_models.json_attributes ->> 'gbl_mdVersion_s'::text) AS "gbl_mdVersion_s",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'gbl_suppressed_b'::text), ''::text), 'null'::text))::boolean AS gbl_suppressed_b,
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'gbl_georeferenced_b'::text), ''::text), 'null'::text))::boolean AS gbl_georeferenced_b,
-              (kithe_models.json_attributes ->> 'b1g_code_s'::text) AS b1g_code_s,
-              (kithe_models.json_attributes ->> 'b1g_status_s'::text) AS b1g_status_s,
-              (kithe_models.json_attributes ->> 'b1g_dct_accrualMethod_s'::text) AS "b1g_dct_accrualMethod_s",
-              (kithe_models.json_attributes ->> 'b1g_dct_accrualPeriodicity_s'::text) AS "b1g_dct_accrualPeriodicity_s",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateAccessioned_s'::text), ''::text), 'null'::text))::date AS "b1g_dateAccessioned_s",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'gbl_mdModified_dt'::text), ''::text), 'null'::text))::timestamp without time zone AS "gbl_mdModified_dt",
+              (live_document_ids.json_attributes ->> 'gbl_mdVersion_s'::text) AS "gbl_mdVersion_s",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'gbl_suppressed_b'::text), ''::text), 'null'::text))::boolean AS gbl_suppressed_b,
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'gbl_georeferenced_b'::text), ''::text), 'null'::text))::boolean AS gbl_georeferenced_b,
+              (live_document_ids.json_attributes ->> 'b1g_code_s'::text) AS b1g_code_s,
+              (live_document_ids.json_attributes ->> 'b1g_status_s'::text) AS b1g_status_s,
+              (live_document_ids.json_attributes ->> 'b1g_dct_accrualMethod_s'::text) AS "b1g_dct_accrualMethod_s",
+              (live_document_ids.json_attributes ->> 'b1g_dct_accrualPeriodicity_s'::text) AS "b1g_dct_accrualPeriodicity_s",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateAccessioned_s'::text), ''::text), 'null'::text))::date AS "b1g_dateAccessioned_s",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dateAccessioned_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dateAccessioned_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dateAccessioned_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dateAccessioned_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dateAccessioned_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dateAccessioned_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dateAccessioned_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dateAccessioned_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dateAccessioned_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dateAccessioned_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_dateAccessioned_sm",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateRetired_s'::text), ''::text), 'null'::text))::date AS "b1g_dateRetired_s",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_child_record_b'::text), ''::text), 'null'::text))::boolean AS b1g_child_record_b,
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateRetired_s'::text), ''::text), 'null'::text))::date AS "b1g_dateRetired_s",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_child_record_b'::text), ''::text), 'null'::text))::boolean AS b1g_child_record_b,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dct_mediator_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dct_mediator_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dct_mediator_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dct_mediator_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dct_mediator_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dct_mediator_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dct_mediator_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dct_mediator_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dct_mediator_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dct_mediator_sm'::text))
                           END) AS jsonb_array_elements_text) AS b1g_dct_mediator_sm,
                   CASE
-                      WHEN (((kithe_models.json_attributes -> 'b1g_access_s'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_access_s'::text) = 'null'::jsonb)) THEN NULL::jsonb
-                      WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_access_s'::text)) = 'string'::text) THEN
+                      WHEN (((live_document_ids.json_attributes -> 'b1g_access_s'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_access_s'::text) = 'null'::jsonb)) THEN NULL::jsonb
+                      WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_access_s'::text)) = 'string'::text) THEN
                       CASE
-                          WHEN (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_access_s'::text), ''::text), 'null'::text) IS NULL) THEN NULL::jsonb
-                          ELSE to_jsonb((kithe_models.json_attributes ->> 'b1g_access_s'::text))
+                          WHEN (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_access_s'::text), ''::text), 'null'::text) IS NULL) THEN NULL::jsonb
+                          ELSE to_jsonb((live_document_ids.json_attributes ->> 'b1g_access_s'::text))
                       END
-                      ELSE (kithe_models.json_attributes -> 'b1g_access_s'::text)
+                      ELSE (live_document_ids.json_attributes -> 'b1g_access_s'::text)
                   END AS b1g_access_s,
-              (kithe_models.json_attributes ->> 'b1g_image_ss'::text) AS b1g_image_ss,
+              (live_document_ids.json_attributes ->> 'b1g_image_ss'::text) AS b1g_image_ss,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_geonames_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_geonames_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_geonames_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_geonames_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_geonames_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_geonames_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_geonames_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_geonames_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_geonames_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_geonames_sm'::text))
                           END) AS jsonb_array_elements_text) AS b1g_geonames_sm,
-              (kithe_models.json_attributes ->> 'b1g_publication_state_s'::text) AS b1g_publication_state_s,
+              (live_document_ids.json_attributes ->> 'b1g_publication_state_s'::text) AS b1g_publication_state_s,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_language_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_language_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_language_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_language_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_language_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_language_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_language_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_language_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_language_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_language_sm'::text))
                           END) AS jsonb_array_elements_text) AS b1g_language_sm,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_creatorID_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_creatorID_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_creatorID_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_creatorID_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_creatorID_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_creatorID_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_creatorID_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_creatorID_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_creatorID_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_creatorID_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_creatorID_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dct_conformsTo_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dct_conformsTo_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dct_conformsTo_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dct_conformsTo_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dct_conformsTo_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dct_conformsTo_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dct_conformsTo_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dct_conformsTo_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dct_conformsTo_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dct_conformsTo_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_dct_conformsTo_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_dcat_spatialResolutionInMeters_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_geodcat_spatialResolutionAsText_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_geodcat_spatialResolutionAsText_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_dct_provenanceStatement_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_adminTags_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_adminTags_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_adminTags_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_adminTags_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_adminTags_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_adminTags_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_adminTags_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_adminTags_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_adminTags_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_adminTags_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_adminTags_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_adms_supportedSchema_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_adms_supportedSchema_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_adms_supportedSchema_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_adms_supportedSchema_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_adms_supportedSchema_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_adms_supportedSchema_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_adms_supportedSchema_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_adms_supportedSchema_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_adms_supportedSchema_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_adms_supportedSchema_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_adms_supportedSchema_sm",
-              (kithe_models.json_attributes ->> 'b1g_dcat_endpointDescription_s'::text) AS "b1g_dcat_endpointDescription_s",
-              (kithe_models.json_attributes ->> 'b1g_dcat_endpointURL_s'::text) AS "b1g_dcat_endpointURL_s",
+              (live_document_ids.json_attributes ->> 'b1g_dcat_endpointDescription_s'::text) AS "b1g_dcat_endpointDescription_s",
+              (live_document_ids.json_attributes ->> 'b1g_dcat_endpointURL_s'::text) AS "b1g_dcat_endpointURL_s",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_dcat_inSeries_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_dcat_inSeries_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_dcat_inSeries_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_dcat_inSeries_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_dcat_inSeries_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_dcat_inSeries_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_dcat_inSeries_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_dcat_inSeries_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_dcat_inSeries_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_dcat_inSeries_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_dcat_inSeries_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_localCollectionLabel_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_localCollectionLabel_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_localCollectionLabel_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_localCollectionLabel_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_localCollectionLabel_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_localCollectionLabel_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_localCollectionLabel_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_localCollectionLabel_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_localCollectionLabel_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_localCollectionLabel_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_localCollectionLabel_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_prov_softwareAgent_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_prov_softwareAgent_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_prov_softwareAgent_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_prov_softwareAgent_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_prov_softwareAgent_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_prov_softwareAgent_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_prov_softwareAgent_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_prov_softwareAgent_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_prov_softwareAgent_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_prov_softwareAgent_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_prov_softwareAgent_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_prov_wasGeneratedBy_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_prov_wasGeneratedBy_sm",
-              COALESCE((NULLIF(NULLIF((kithe_models.json_attributes ->> 'date_created_dtsi'::text), ''::text), 'null'::text))::timestamp without time zone, kithe_models.created_at) AS date_created_dtsi,
-              COALESCE((NULLIF(NULLIF((kithe_models.json_attributes ->> 'date_modified_dtsi'::text), ''::text), 'null'::text))::timestamp without time zone, kithe_models.updated_at) AS date_modified_dtsi,
-              kithe_models.updated_at AS kithe_updated_at,
-              (kithe_models.json_attributes ->> 'geomg_id_s'::text) AS geomg_id_s,
+              COALESCE((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'date_created_dtsi'::text), ''::text), 'null'::text))::timestamp without time zone, live_document_ids.created_at) AS date_created_dtsi,
+              COALESCE((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'date_modified_dtsi'::text), ''::text), 'null'::text))::timestamp without time zone, live_document_ids.updated_at) AS date_modified_dtsi,
+              live_document_ids.updated_at AS kithe_updated_at,
+              (live_document_ids.json_attributes ->> 'geomg_id_s'::text) AS geomg_id_s,
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (((kithe_models.json_attributes -> 'b1g_adminNote_sm'::text) IS NULL) OR ((kithe_models.json_attributes -> 'b1g_adminNote_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
-                              WHEN (jsonb_typeof((kithe_models.json_attributes -> 'b1g_adminNote_sm'::text)) = 'array'::text) THEN (kithe_models.json_attributes -> 'b1g_adminNote_sm'::text)
-                              ELSE jsonb_build_array((kithe_models.json_attributes -> 'b1g_adminNote_sm'::text))
+                              WHEN (((live_document_ids.json_attributes -> 'b1g_adminNote_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'b1g_adminNote_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
+                              WHEN (jsonb_typeof((live_document_ids.json_attributes -> 'b1g_adminNote_sm'::text)) = 'array'::text) THEN (live_document_ids.json_attributes -> 'b1g_adminNote_sm'::text)
+                              ELSE jsonb_build_array((live_document_ids.json_attributes -> 'b1g_adminNote_sm'::text))
                           END) AS jsonb_array_elements_text) AS "b1g_adminNote_sm",
-              COALESCE((NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateAccessioned_dt'::text), ''::text), 'null'::text))::timestamp without time zone, ((NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateAccessioned_s'::text), ''::text), 'null'::text))::date)::timestamp without time zone) AS "b1g_dateAccessioned_dt",
-              COALESCE((NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateRetired_dt'::text), ''::text), 'null'::text))::timestamp without time zone, ((NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dateRetired_s'::text), ''::text), 'null'::text))::date)::timestamp without time zone) AS "b1g_dateRetired_dt",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_deprioritized_b'::text), ''::text), 'null'::text))::boolean AS b1g_deprioritized_b,
-              (kithe_models.json_attributes ->> 'b1g_harvestWorkflow_s'::text) AS "b1g_harvestWorkflow_s",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_isHarvested_b'::text), ''::text), 'null'::text))::boolean AS "b1g_isHarvested_b",
-              (NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_lastHarvested_dt'::text), ''::text), 'null'::text))::timestamp without time zone AS "b1g_lastHarvested_dt",
+              COALESCE((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateAccessioned_dt'::text), ''::text), 'null'::text))::timestamp without time zone, ((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateAccessioned_s'::text), ''::text), 'null'::text))::date)::timestamp without time zone) AS "b1g_dateAccessioned_dt",
+              COALESCE((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateRetired_dt'::text), ''::text), 'null'::text))::timestamp without time zone, ((NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dateRetired_s'::text), ''::text), 'null'::text))::date)::timestamp without time zone) AS "b1g_dateRetired_dt",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_deprioritized_b'::text), ''::text), 'null'::text))::boolean AS b1g_deprioritized_b,
+              (live_document_ids.json_attributes ->> 'b1g_harvestWorkflow_s'::text) AS "b1g_harvestWorkflow_s",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_isHarvested_b'::text), ''::text), 'null'::text))::boolean AS "b1g_isHarvested_b",
+              (NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_lastHarvested_dt'::text), ''::text), 'null'::text))::timestamp without time zone AS "b1g_lastHarvested_dt",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
-                              WHEN (jsonb_typeof(COALESCE((kithe_models.json_attributes -> 'b1g_dct_provenance_sm'::text), (kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))) = 'array'::text) THEN COALESCE((kithe_models.json_attributes -> 'b1g_dct_provenance_sm'::text), (kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))
-                              WHEN (jsonb_typeof(COALESCE((kithe_models.json_attributes -> 'b1g_dct_provenance_sm'::text), (kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))) = 'string'::text) THEN jsonb_build_array(COALESCE((kithe_models.json_attributes -> 'b1g_dct_provenance_sm'::text), (kithe_models.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)))
+                              WHEN (jsonb_typeof(COALESCE((live_document_ids.json_attributes -> 'b1g_dct_provenance_sm'::text), (live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))) = 'array'::text) THEN COALESCE((live_document_ids.json_attributes -> 'b1g_dct_provenance_sm'::text), (live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))
+                              WHEN (jsonb_typeof(COALESCE((live_document_ids.json_attributes -> 'b1g_dct_provenance_sm'::text), (live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text))) = 'string'::text) THEN jsonb_build_array(COALESCE((live_document_ids.json_attributes -> 'b1g_dct_provenance_sm'::text), (live_document_ids.json_attributes -> 'b1g_dct_provenanceStatement_sm'::text)))
                               ELSE '[]'::jsonb
                           END) AS jsonb_array_elements_text) AS b1g_dct_provenance_sm,
-              COALESCE(NULLIF(NULLIF((kithe_models.json_attributes ->> 'b1g_dcat_spatialResolutionInMeters_s'::text), ''::text), 'null'::text), NULLIF(NULLIF(((kithe_models.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) ->> 0), ''::text), 'null'::text)) AS "b1g_dcat_spatialResolutionInMeters_s",
-              (kithe_models.json_attributes ->> 'b1g_websitePlatform_s'::text) AS "b1g_websitePlatform_s",
+              COALESCE(NULLIF(NULLIF((live_document_ids.json_attributes ->> 'b1g_dcat_spatialResolutionInMeters_s'::text), ''::text), 'null'::text), NULLIF(NULLIF(((live_document_ids.json_attributes -> 'b1g_dcat_spatialResolutionInMeters_sm'::text) ->> 0), ''::text), 'null'::text)) AS "b1g_dcat_spatialResolutionInMeters_s",
+              (live_document_ids.json_attributes ->> 'b1g_websitePlatform_s'::text) AS "b1g_websitePlatform_s",
               false AS deleted,
               NULL::timestamp without time zone AS deleted_at
-             FROM kithe_models
-            WHERE ((kithe_models.type)::text = 'Document'::text)
+             FROM live_document_ids
           ), deleted_documents AS (
            SELECT tombstones.friendlier_id AS id,
               tombstones.title AS dct_title_s,

--- a/db/views/kithe_to_resources_bridge_v06.sql
+++ b/db/views/kithe_to_resources_bridge_v06.sql
@@ -1,0 +1,310 @@
+WITH live_document_ids AS (
+  SELECT
+    kithe_models.*,
+    COALESCE(kithe_models.friendlier_id::varchar, kithe_models.id::varchar)::varchar AS bridge_id
+  FROM kithe_models
+  WHERE type = 'Document'
+),
+relationship_values AS (
+  SELECT
+    live_document_ids.bridge_id AS subject_id,
+    relation_fields.field_name,
+    btrim(related_ids.related_id) AS object_id
+  FROM live_document_ids
+  CROSS JOIN LATERAL (
+    VALUES
+      ('dct_relation_sm', live_document_ids.json_attributes->'dct_relation_sm'),
+      ('pcdm_memberOf_sm', live_document_ids.json_attributes->'pcdm_memberOf_sm'),
+      ('dct_isPartOf_sm', live_document_ids.json_attributes->'dct_isPartOf_sm'),
+      ('dct_source_sm', live_document_ids.json_attributes->'dct_source_sm'),
+      ('dct_isVersionOf_sm', live_document_ids.json_attributes->'dct_isVersionOf_sm'),
+      ('dct_replaces_sm', live_document_ids.json_attributes->'dct_replaces_sm'),
+      ('dct_isReplacedBy_sm', live_document_ids.json_attributes->'dct_isReplacedBy_sm')
+  ) AS relation_fields(field_name, raw_value)
+  CROSS JOIN LATERAL jsonb_array_elements_text(
+    CASE
+      WHEN relation_fields.raw_value IS NULL
+        OR relation_fields.raw_value = 'null'::jsonb
+      THEN '[]'::jsonb
+      WHEN jsonb_typeof(relation_fields.raw_value) = 'array'
+      THEN relation_fields.raw_value
+      ELSE jsonb_build_array(relation_fields.raw_value)
+    END
+  ) AS related_ids(related_id)
+  WHERE btrim(related_ids.related_id) <> ''
+),
+relationship_exports AS (
+  SELECT subject_id AS document_id, field_name, object_id AS related_id
+  FROM relationship_values
+  UNION
+  SELECT object_id AS document_id, 'dct_relation_sm' AS field_name, subject_id AS related_id
+  FROM relationship_values
+  WHERE field_name = 'dct_relation_sm'
+  UNION
+  SELECT object_id AS document_id, 'dct_isReplacedBy_sm' AS field_name, subject_id AS related_id
+  FROM relationship_values
+  WHERE field_name = 'dct_replaces_sm'
+  UNION
+  SELECT object_id AS document_id, 'dct_replaces_sm' AS field_name, subject_id AS related_id
+  FROM relationship_values
+  WHERE field_name = 'dct_isReplacedBy_sm'
+),
+live_documents AS (
+  SELECT
+    bridge_id AS "id",
+    title AS "dct_title_s",
+    publication_state AS "publication_state",
+    import_id::varchar AS "import_id",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_alternative_sm' IS NULL OR json_attributes->'dct_alternative_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_alternative_sm') = 'array' THEN json_attributes->'dct_alternative_sm' ELSE jsonb_build_array(json_attributes->'dct_alternative_sm') END)) AS "dct_alternative_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_description_sm' IS NULL OR json_attributes->'dct_description_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_description_sm') = 'array' THEN json_attributes->'dct_description_sm' ELSE jsonb_build_array(json_attributes->'dct_description_sm') END)) AS "dct_description_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_language_sm' IS NULL OR json_attributes->'dct_language_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_language_sm') = 'array' THEN json_attributes->'dct_language_sm' ELSE jsonb_build_array(json_attributes->'dct_language_sm') END)) AS "dct_language_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'gbl_displayNote_sm' IS NULL OR json_attributes->'gbl_displayNote_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'gbl_displayNote_sm') = 'array' THEN json_attributes->'gbl_displayNote_sm' ELSE jsonb_build_array(json_attributes->'gbl_displayNote_sm') END)) AS "gbl_displayNote_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_creator_sm' IS NULL OR json_attributes->'dct_creator_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_creator_sm') = 'array' THEN json_attributes->'dct_creator_sm' ELSE jsonb_build_array(json_attributes->'dct_creator_sm') END)) AS "dct_creator_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_publisher_sm' IS NULL OR json_attributes->'dct_publisher_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_publisher_sm') = 'array' THEN json_attributes->'dct_publisher_sm' ELSE jsonb_build_array(json_attributes->'dct_publisher_sm') END)) AS "dct_publisher_sm",
+    json_attributes->>'schema_provider_s' AS "schema_provider_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'gbl_resourceClass_sm' IS NULL OR json_attributes->'gbl_resourceClass_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'gbl_resourceClass_sm') = 'array' THEN json_attributes->'gbl_resourceClass_sm' ELSE jsonb_build_array(json_attributes->'gbl_resourceClass_sm') END)) AS "gbl_resourceClass_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'gbl_resourceType_sm' IS NULL OR json_attributes->'gbl_resourceType_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'gbl_resourceType_sm') = 'array' THEN json_attributes->'gbl_resourceType_sm' ELSE jsonb_build_array(json_attributes->'gbl_resourceType_sm') END)) AS "gbl_resourceType_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_subject_sm' IS NULL OR json_attributes->'dct_subject_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_subject_sm') = 'array' THEN json_attributes->'dct_subject_sm' ELSE jsonb_build_array(json_attributes->'dct_subject_sm') END)) AS "dct_subject_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dcat_theme_sm' IS NULL OR json_attributes->'dcat_theme_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dcat_theme_sm') = 'array' THEN json_attributes->'dcat_theme_sm' ELSE jsonb_build_array(json_attributes->'dcat_theme_sm') END)) AS "dcat_theme_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dcat_keyword_sm' IS NULL OR json_attributes->'dcat_keyword_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dcat_keyword_sm') = 'array' THEN json_attributes->'dcat_keyword_sm' ELSE jsonb_build_array(json_attributes->'dcat_keyword_sm') END)) AS "dcat_keyword_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_temporal_sm' IS NULL OR json_attributes->'dct_temporal_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_temporal_sm') = 'array' THEN json_attributes->'dct_temporal_sm' ELSE jsonb_build_array(json_attributes->'dct_temporal_sm') END)) AS "dct_temporal_sm",
+    json_attributes->>'dct_issued_s' AS "dct_issued_s",
+    ARRAY(
+      SELECT (
+        jsonb_array_elements_text(
+          CASE
+            WHEN jsonb_typeof(json_attributes->'gbl_indexYear_im') = 'array'
+              THEN json_attributes->'gbl_indexYear_im'
+            WHEN jsonb_typeof(json_attributes->'gbl_indexYear_im') = 'string'
+              THEN jsonb_build_array(json_attributes->'gbl_indexYear_im')
+            ELSE '[]'::jsonb
+          END
+        )
+      )::integer
+    ) AS "gbl_indexYear_im",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'gbl_dateRange_drsim' IS NULL OR json_attributes->'gbl_dateRange_drsim' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'gbl_dateRange_drsim') = 'array' THEN json_attributes->'gbl_dateRange_drsim' ELSE jsonb_build_array(json_attributes->'gbl_dateRange_drsim') END)) AS "gbl_dateRange_drsim",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_spatial_sm' IS NULL OR json_attributes->'dct_spatial_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_spatial_sm') = 'array' THEN json_attributes->'dct_spatial_sm' ELSE jsonb_build_array(json_attributes->'dct_spatial_sm') END)) AS "dct_spatial_sm",
+    json_attributes->>'locn_geometry' AS "locn_geometry",
+    json_attributes->>'dcat_bbox' AS "dcat_bbox",
+    json_attributes->>'dcat_centroid' AS "dcat_centroid",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_relation_sm' ORDER BY related_id) AS "dct_relation_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'pcdm_memberOf_sm' ORDER BY related_id) AS "pcdm_memberOf_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isPartOf_sm' ORDER BY related_id) AS "dct_isPartOf_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_source_sm' ORDER BY related_id) AS "dct_source_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isVersionOf_sm' ORDER BY related_id) AS "dct_isVersionOf_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_replaces_sm' ORDER BY related_id) AS "dct_replaces_sm",
+    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isReplacedBy_sm' ORDER BY related_id) AS "dct_isReplacedBy_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_rights_sm' IS NULL OR json_attributes->'dct_rights_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_rights_sm') = 'array' THEN json_attributes->'dct_rights_sm' ELSE jsonb_build_array(json_attributes->'dct_rights_sm') END)) AS "dct_rights_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_rightsHolder_sm' IS NULL OR json_attributes->'dct_rightsHolder_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_rightsHolder_sm') = 'array' THEN json_attributes->'dct_rightsHolder_sm' ELSE jsonb_build_array(json_attributes->'dct_rightsHolder_sm') END)) AS "dct_rightsHolder_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_license_sm' IS NULL OR json_attributes->'dct_license_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_license_sm') = 'array' THEN json_attributes->'dct_license_sm' ELSE jsonb_build_array(json_attributes->'dct_license_sm') END)) AS "dct_license_sm",
+    json_attributes->>'dct_accessRights_s' AS "dct_accessRights_s",
+    json_attributes->>'dct_format_s' AS "dct_format_s",
+    json_attributes->>'gbl_fileSize_s' AS "gbl_fileSize_s",
+    json_attributes->>'gbl_wxsIdentifier_s' AS "gbl_wxsIdentifier_s",
+    json_attributes->>'dct_references_s' AS "dct_references_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_identifier_sm' IS NULL OR json_attributes->'dct_identifier_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_identifier_sm') = 'array' THEN json_attributes->'dct_identifier_sm' ELSE jsonb_build_array(json_attributes->'dct_identifier_sm') END)) AS "dct_identifier_sm",
+    NULLIF(NULLIF(json_attributes->>'gbl_mdModified_dt', ''), 'null')::timestamp AS "gbl_mdModified_dt",
+    json_attributes->>'gbl_mdVersion_s' AS "gbl_mdVersion_s",
+    NULLIF(NULLIF(json_attributes->>'gbl_suppressed_b', ''), 'null')::boolean AS "gbl_suppressed_b",
+    NULLIF(NULLIF(json_attributes->>'gbl_georeferenced_b', ''), 'null')::boolean AS "gbl_georeferenced_b",
+    json_attributes->>'b1g_code_s' AS "b1g_code_s",
+    json_attributes->>'b1g_status_s' AS "b1g_status_s",
+    json_attributes->>'b1g_dct_accrualMethod_s' AS "b1g_dct_accrualMethod_s",
+    json_attributes->>'b1g_dct_accrualPeriodicity_s' AS "b1g_dct_accrualPeriodicity_s",
+    NULLIF(NULLIF(json_attributes->>'b1g_dateAccessioned_s', ''), 'null')::date AS "b1g_dateAccessioned_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dateAccessioned_sm' IS NULL OR json_attributes->'b1g_dateAccessioned_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dateAccessioned_sm') = 'array' THEN json_attributes->'b1g_dateAccessioned_sm' ELSE jsonb_build_array(json_attributes->'b1g_dateAccessioned_sm') END)) AS "b1g_dateAccessioned_sm",
+    NULLIF(NULLIF(json_attributes->>'b1g_dateRetired_s', ''), 'null')::date AS "b1g_dateRetired_s",
+    NULLIF(NULLIF(json_attributes->>'b1g_child_record_b', ''), 'null')::boolean AS "b1g_child_record_b",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dct_mediator_sm' IS NULL OR json_attributes->'b1g_dct_mediator_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dct_mediator_sm') = 'array' THEN json_attributes->'b1g_dct_mediator_sm' ELSE jsonb_build_array(json_attributes->'b1g_dct_mediator_sm') END)) AS "b1g_dct_mediator_sm",
+    CASE
+      WHEN json_attributes->'b1g_access_s' IS NULL
+        OR json_attributes->'b1g_access_s' = 'null'::jsonb
+      THEN NULL
+      WHEN jsonb_typeof(json_attributes->'b1g_access_s') = 'string'
+      THEN CASE
+        WHEN NULLIF(NULLIF(json_attributes->>'b1g_access_s', ''), 'null') IS NULL
+        THEN NULL
+        ELSE to_jsonb(json_attributes->>'b1g_access_s')
+      END
+      ELSE json_attributes->'b1g_access_s'
+    END AS "b1g_access_s",
+    json_attributes->>'b1g_image_ss' AS "b1g_image_ss",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_geonames_sm' IS NULL OR json_attributes->'b1g_geonames_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_geonames_sm') = 'array' THEN json_attributes->'b1g_geonames_sm' ELSE jsonb_build_array(json_attributes->'b1g_geonames_sm') END)) AS "b1g_geonames_sm",
+    json_attributes->>'b1g_publication_state_s' AS "b1g_publication_state_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_language_sm' IS NULL OR json_attributes->'b1g_language_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_language_sm') = 'array' THEN json_attributes->'b1g_language_sm' ELSE jsonb_build_array(json_attributes->'b1g_language_sm') END)) AS "b1g_language_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_creatorID_sm' IS NULL OR json_attributes->'b1g_creatorID_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_creatorID_sm') = 'array' THEN json_attributes->'b1g_creatorID_sm' ELSE jsonb_build_array(json_attributes->'b1g_creatorID_sm') END)) AS "b1g_creatorID_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dct_conformsTo_sm' IS NULL OR json_attributes->'b1g_dct_conformsTo_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dct_conformsTo_sm') = 'array' THEN json_attributes->'b1g_dct_conformsTo_sm' ELSE jsonb_build_array(json_attributes->'b1g_dct_conformsTo_sm') END)) AS "b1g_dct_conformsTo_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dcat_spatialResolutionInMeters_sm' IS NULL OR json_attributes->'b1g_dcat_spatialResolutionInMeters_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dcat_spatialResolutionInMeters_sm') = 'array' THEN json_attributes->'b1g_dcat_spatialResolutionInMeters_sm' ELSE jsonb_build_array(json_attributes->'b1g_dcat_spatialResolutionInMeters_sm') END)) AS "b1g_dcat_spatialResolutionInMeters_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_geodcat_spatialResolutionAsText_sm' IS NULL OR json_attributes->'b1g_geodcat_spatialResolutionAsText_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_geodcat_spatialResolutionAsText_sm') = 'array' THEN json_attributes->'b1g_geodcat_spatialResolutionAsText_sm' ELSE jsonb_build_array(json_attributes->'b1g_geodcat_spatialResolutionAsText_sm') END)) AS "b1g_geodcat_spatialResolutionAsText_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dct_provenanceStatement_sm' IS NULL OR json_attributes->'b1g_dct_provenanceStatement_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dct_provenanceStatement_sm') = 'array' THEN json_attributes->'b1g_dct_provenanceStatement_sm' ELSE jsonb_build_array(json_attributes->'b1g_dct_provenanceStatement_sm') END)) AS "b1g_dct_provenanceStatement_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_adminTags_sm' IS NULL OR json_attributes->'b1g_adminTags_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_adminTags_sm') = 'array' THEN json_attributes->'b1g_adminTags_sm' ELSE jsonb_build_array(json_attributes->'b1g_adminTags_sm') END)) AS "b1g_adminTags_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_adms_supportedSchema_sm' IS NULL OR json_attributes->'b1g_adms_supportedSchema_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_adms_supportedSchema_sm') = 'array' THEN json_attributes->'b1g_adms_supportedSchema_sm' ELSE jsonb_build_array(json_attributes->'b1g_adms_supportedSchema_sm') END)) AS "b1g_adms_supportedSchema_sm",
+    json_attributes->>'b1g_dcat_endpointDescription_s' AS "b1g_dcat_endpointDescription_s",
+    json_attributes->>'b1g_dcat_endpointURL_s' AS "b1g_dcat_endpointURL_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_dcat_inSeries_sm' IS NULL OR json_attributes->'b1g_dcat_inSeries_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_dcat_inSeries_sm') = 'array' THEN json_attributes->'b1g_dcat_inSeries_sm' ELSE jsonb_build_array(json_attributes->'b1g_dcat_inSeries_sm') END)) AS "b1g_dcat_inSeries_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_localCollectionLabel_sm' IS NULL OR json_attributes->'b1g_localCollectionLabel_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_localCollectionLabel_sm') = 'array' THEN json_attributes->'b1g_localCollectionLabel_sm' ELSE jsonb_build_array(json_attributes->'b1g_localCollectionLabel_sm') END)) AS "b1g_localCollectionLabel_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_prov_softwareAgent_sm' IS NULL OR json_attributes->'b1g_prov_softwareAgent_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_prov_softwareAgent_sm') = 'array' THEN json_attributes->'b1g_prov_softwareAgent_sm' ELSE jsonb_build_array(json_attributes->'b1g_prov_softwareAgent_sm') END)) AS "b1g_prov_softwareAgent_sm",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_prov_wasGeneratedBy_sm' IS NULL OR json_attributes->'b1g_prov_wasGeneratedBy_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_prov_wasGeneratedBy_sm') = 'array' THEN json_attributes->'b1g_prov_wasGeneratedBy_sm' ELSE jsonb_build_array(json_attributes->'b1g_prov_wasGeneratedBy_sm') END)) AS "b1g_prov_wasGeneratedBy_sm",
+    COALESCE(
+      NULLIF(NULLIF(json_attributes->>'date_created_dtsi', ''), 'null')::timestamp,
+      created_at
+    ) AS "date_created_dtsi",
+    COALESCE(
+      NULLIF(NULLIF(json_attributes->>'date_modified_dtsi', ''), 'null')::timestamp,
+      updated_at
+    ) AS "date_modified_dtsi",
+    updated_at AS "kithe_updated_at",
+    json_attributes->>'geomg_id_s' AS "geomg_id_s",
+    ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'b1g_adminNote_sm' IS NULL OR json_attributes->'b1g_adminNote_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'b1g_adminNote_sm') = 'array' THEN json_attributes->'b1g_adminNote_sm' ELSE jsonb_build_array(json_attributes->'b1g_adminNote_sm') END)) AS "b1g_adminNote_sm",
+    COALESCE(
+      NULLIF(NULLIF(json_attributes->>'b1g_dateAccessioned_dt', ''), 'null')::timestamp,
+      NULLIF(NULLIF(json_attributes->>'b1g_dateAccessioned_s', ''), 'null')::date::timestamp
+    ) AS "b1g_dateAccessioned_dt",
+    COALESCE(
+      NULLIF(NULLIF(json_attributes->>'b1g_dateRetired_dt', ''), 'null')::timestamp,
+      NULLIF(NULLIF(json_attributes->>'b1g_dateRetired_s', ''), 'null')::date::timestamp
+    ) AS "b1g_dateRetired_dt",
+    NULLIF(NULLIF(json_attributes->>'b1g_deprioritized_b', ''), 'null')::boolean AS "b1g_deprioritized_b",
+    json_attributes->>'b1g_harvestWorkflow_s' AS "b1g_harvestWorkflow_s",
+    NULLIF(NULLIF(json_attributes->>'b1g_isHarvested_b', ''), 'null')::boolean AS "b1g_isHarvested_b",
+    NULLIF(NULLIF(json_attributes->>'b1g_lastHarvested_dt', ''), 'null')::timestamp AS "b1g_lastHarvested_dt",
+    ARRAY(
+      SELECT jsonb_array_elements_text(
+        CASE
+          WHEN jsonb_typeof(
+            COALESCE(
+              json_attributes->'b1g_dct_provenance_sm',
+              json_attributes->'b1g_dct_provenanceStatement_sm'
+            )
+          ) = 'array'
+          THEN COALESCE(
+            json_attributes->'b1g_dct_provenance_sm',
+            json_attributes->'b1g_dct_provenanceStatement_sm'
+          )
+          WHEN jsonb_typeof(
+            COALESCE(
+              json_attributes->'b1g_dct_provenance_sm',
+              json_attributes->'b1g_dct_provenanceStatement_sm'
+            )
+          ) = 'string'
+          THEN jsonb_build_array(
+            COALESCE(
+              json_attributes->'b1g_dct_provenance_sm',
+              json_attributes->'b1g_dct_provenanceStatement_sm'
+            )
+          )
+          ELSE '[]'::jsonb
+        END
+      )
+    ) AS "b1g_dct_provenance_sm",
+    COALESCE(
+      NULLIF(NULLIF(json_attributes->>'b1g_dcat_spatialResolutionInMeters_s', ''), 'null'),
+      NULLIF(NULLIF((json_attributes->'b1g_dcat_spatialResolutionInMeters_sm'->>0), ''), 'null')
+    ) AS "b1g_dcat_spatialResolutionInMeters_s",
+    json_attributes->>'b1g_websitePlatform_s' AS "b1g_websitePlatform_s",
+    FALSE AS "deleted",
+    NULL::timestamp AS "deleted_at"
+  FROM live_document_ids
+),
+deleted_documents AS (
+  SELECT
+    tombstones.friendlier_id::varchar AS "id",
+    tombstones.title AS "dct_title_s",
+    tombstones.publication_state AS "publication_state",
+    tombstones.import_id::varchar AS "import_id",
+    ARRAY[]::text[] AS "dct_alternative_sm",
+    ARRAY[]::text[] AS "dct_description_sm",
+    ARRAY[]::text[] AS "dct_language_sm",
+    ARRAY[]::text[] AS "gbl_displayNote_sm",
+    ARRAY[]::text[] AS "dct_creator_sm",
+    ARRAY[]::text[] AS "dct_publisher_sm",
+    NULL::text AS "schema_provider_s",
+    ARRAY[]::text[] AS "gbl_resourceClass_sm",
+    ARRAY[]::text[] AS "gbl_resourceType_sm",
+    ARRAY[]::text[] AS "dct_subject_sm",
+    ARRAY[]::text[] AS "dcat_theme_sm",
+    ARRAY[]::text[] AS "dcat_keyword_sm",
+    ARRAY[]::text[] AS "dct_temporal_sm",
+    NULL::text AS "dct_issued_s",
+    ARRAY[]::integer[] AS "gbl_indexYear_im",
+    ARRAY[]::text[] AS "gbl_dateRange_drsim",
+    ARRAY[]::text[] AS "dct_spatial_sm",
+    NULL::text AS "locn_geometry",
+    NULL::text AS "dcat_bbox",
+    NULL::text AS "dcat_centroid",
+    ARRAY[]::text[] AS "dct_relation_sm",
+    ARRAY[]::text[] AS "pcdm_memberOf_sm",
+    ARRAY[]::text[] AS "dct_isPartOf_sm",
+    ARRAY[]::text[] AS "dct_source_sm",
+    ARRAY[]::text[] AS "dct_isVersionOf_sm",
+    ARRAY[]::text[] AS "dct_replaces_sm",
+    ARRAY[]::text[] AS "dct_isReplacedBy_sm",
+    ARRAY[]::text[] AS "dct_rights_sm",
+    ARRAY[]::text[] AS "dct_rightsHolder_sm",
+    ARRAY[]::text[] AS "dct_license_sm",
+    NULL::text AS "dct_accessRights_s",
+    NULL::text AS "dct_format_s",
+    NULL::text AS "gbl_fileSize_s",
+    NULL::text AS "gbl_wxsIdentifier_s",
+    NULL::text AS "dct_references_s",
+    ARRAY[]::text[] AS "dct_identifier_sm",
+    NULL::timestamp AS "gbl_mdModified_dt",
+    NULL::text AS "gbl_mdVersion_s",
+    NULL::boolean AS "gbl_suppressed_b",
+    NULL::boolean AS "gbl_georeferenced_b",
+    NULL::text AS "b1g_code_s",
+    NULL::text AS "b1g_status_s",
+    NULL::text AS "b1g_dct_accrualMethod_s",
+    NULL::text AS "b1g_dct_accrualPeriodicity_s",
+    NULL::date AS "b1g_dateAccessioned_s",
+    ARRAY[]::text[] AS "b1g_dateAccessioned_sm",
+    NULL::date AS "b1g_dateRetired_s",
+    NULL::boolean AS "b1g_child_record_b",
+    ARRAY[]::text[] AS "b1g_dct_mediator_sm",
+    NULL::jsonb AS "b1g_access_s",
+    NULL::text AS "b1g_image_ss",
+    ARRAY[]::text[] AS "b1g_geonames_sm",
+    tombstones.publication_state AS "b1g_publication_state_s",
+    ARRAY[]::text[] AS "b1g_language_sm",
+    ARRAY[]::text[] AS "b1g_creatorID_sm",
+    ARRAY[]::text[] AS "b1g_dct_conformsTo_sm",
+    ARRAY[]::text[] AS "b1g_dcat_spatialResolutionInMeters_sm",
+    ARRAY[]::text[] AS "b1g_geodcat_spatialResolutionAsText_sm",
+    ARRAY[]::text[] AS "b1g_dct_provenanceStatement_sm",
+    ARRAY[]::text[] AS "b1g_adminTags_sm",
+    ARRAY[]::text[] AS "b1g_adms_supportedSchema_sm",
+    NULL::text AS "b1g_dcat_endpointDescription_s",
+    NULL::text AS "b1g_dcat_endpointURL_s",
+    ARRAY[]::text[] AS "b1g_dcat_inSeries_sm",
+    ARRAY[]::text[] AS "b1g_localCollectionLabel_sm",
+    ARRAY[]::text[] AS "b1g_prov_softwareAgent_sm",
+    ARRAY[]::text[] AS "b1g_prov_wasGeneratedBy_sm",
+    NULL::timestamp AS "date_created_dtsi",
+    tombstones.deleted_at AS "date_modified_dtsi",
+    tombstones.deleted_at AS "kithe_updated_at",
+    tombstones.geomg_id_s AS "geomg_id_s",
+    ARRAY[]::text[] AS "b1g_adminNote_sm",
+    NULL::timestamp AS "b1g_dateAccessioned_dt",
+    NULL::timestamp AS "b1g_dateRetired_dt",
+    NULL::boolean AS "b1g_deprioritized_b",
+    NULL::text AS "b1g_harvestWorkflow_s",
+    NULL::boolean AS "b1g_isHarvested_b",
+    NULL::timestamp AS "b1g_lastHarvested_dt",
+    ARRAY[]::text[] AS "b1g_dct_provenance_sm",
+    NULL::text AS "b1g_dcat_spatialResolutionInMeters_s",
+    NULL::text AS "b1g_websitePlatform_s",
+    TRUE AS "deleted",
+    tombstones.deleted_at AS "deleted_at"
+  FROM kithe_bridge_deletions tombstones
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM kithe_models
+    WHERE type = 'Document'
+      AND COALESCE(friendlier_id::varchar, id::varchar)::varchar = tombstones.friendlier_id::varchar
+  )
+)
+SELECT *
+FROM live_documents
+UNION ALL
+SELECT *
+FROM deleted_documents;

--- a/test/models/kithe_to_resources_bridge_test.rb
+++ b/test/models/kithe_to_resources_bridge_test.rb
@@ -1,0 +1,137 @@
+require 'test_helper'
+
+class KitheToResourcesBridgeTest < ActiveSupport::TestCase
+  TEST_IDS = %w[
+    bridge-direct-relations
+    bridge-related-source
+    bridge-related-target
+    bridge-replaced-old
+    bridge-replaced-new
+    bridge-explicit-old
+    bridge-explicit-new
+  ].freeze
+
+  setup do
+    cleanup_test_documents
+  end
+
+  teardown do
+    cleanup_test_documents
+  end
+
+  test "exports stored relation fields" do
+    insert_document(
+      "bridge-direct-relations",
+      {
+        "dct_relation_sm" => ["bridge-related-target"],
+        "pcdm_memberOf_sm" => ["collection-record"],
+        "dct_isPartOf_sm" => ["parent-record"],
+        "dct_source_sm" => ["source-record"],
+        "dct_isVersionOf_sm" => ["version-record"],
+        "dct_replaces_sm" => ["deprecated-record"],
+        "dct_isReplacedBy_sm" => ["replacement-record"]
+      }
+    )
+    refresh_bridge_view
+
+    row = KitheToResourcesBridge.find("bridge-direct-relations")
+
+    assert_equal ["bridge-related-target"], row.dct_relation_sm
+    assert_equal ["collection-record"], row.pcdm_memberOf_sm
+    assert_equal ["parent-record"], row.dct_isPartOf_sm
+    assert_equal ["source-record"], row.dct_source_sm
+    assert_equal ["version-record"], row.dct_isVersionOf_sm
+    assert_equal ["deprecated-record"], row.dct_replaces_sm
+    assert_equal ["replacement-record"], row.dct_isReplacedBy_sm
+  end
+
+  test "exports symmetric relation values from either side" do
+    insert_document(
+      "bridge-related-source",
+      { "dct_relation_sm" => ["bridge-related-target"] }
+    )
+    insert_document("bridge-related-target")
+    refresh_bridge_view
+
+    source = KitheToResourcesBridge.find("bridge-related-source")
+    target = KitheToResourcesBridge.find("bridge-related-target")
+
+    assert_equal ["bridge-related-target"], source.dct_relation_sm
+    assert_equal ["bridge-related-source"], target.dct_relation_sm
+  end
+
+  test "exports replacement inverses into the matching Aardvark fields" do
+    insert_document("bridge-replaced-old")
+    insert_document(
+      "bridge-replaced-new",
+      { "dct_replaces_sm" => ["bridge-replaced-old"] }
+    )
+    insert_document(
+      "bridge-explicit-old",
+      { "dct_isReplacedBy_sm" => ["bridge-explicit-new"] }
+    )
+    insert_document("bridge-explicit-new")
+    refresh_bridge_view
+
+    old_row = KitheToResourcesBridge.find("bridge-replaced-old")
+    new_row = KitheToResourcesBridge.find("bridge-replaced-new")
+    explicit_old_row = KitheToResourcesBridge.find("bridge-explicit-old")
+    explicit_new_row = KitheToResourcesBridge.find("bridge-explicit-new")
+
+    assert_equal ["bridge-replaced-new"], old_row.dct_isReplacedBy_sm
+    assert_equal ["bridge-replaced-old"], new_row.dct_replaces_sm
+    assert_equal ["bridge-explicit-new"], explicit_old_row.dct_isReplacedBy_sm
+    assert_equal ["bridge-explicit-old"], explicit_new_row.dct_replaces_sm
+  end
+
+  private
+
+  def insert_document(friendlier_id, json_attributes = {})
+    quoted_id = connection.quote(friendlier_id)
+    quoted_title = connection.quote("Bridge Test #{friendlier_id}")
+    quoted_json = connection.quote(json_attributes.to_json)
+
+    connection.execute(<<~SQL.squish)
+      INSERT INTO kithe_models (
+        title,
+        type,
+        json_attributes,
+        created_at,
+        updated_at,
+        friendlier_id,
+        kithe_model_type,
+        publication_state
+      )
+      VALUES (
+        #{quoted_title},
+        'Document',
+        #{quoted_json}::jsonb,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP,
+        #{quoted_id},
+        1,
+        'published'
+      )
+    SQL
+  end
+
+  def cleanup_test_documents
+    quoted_ids = TEST_IDS.map { |id| connection.quote(id) }.join(", ")
+    connection.execute("DELETE FROM kithe_models WHERE friendlier_id IN (#{quoted_ids})")
+    refresh_bridge_view if bridge_view_exists?
+  end
+
+  def refresh_bridge_view
+    connection.execute("REFRESH MATERIALIZED VIEW kithe_to_resources_bridge")
+  end
+
+  def bridge_view_exists?
+    connection.select_value(<<~SQL.squish)
+      SELECT to_regclass('kithe_to_resources_bridge') IS NOT NULL
+    SQL
+  end
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+end


### PR DESCRIPTION
## Summary

- add Scenic v6 for `kithe_to_resources_bridge`
- export Bridge relation values through a shared relationship CTE
- fold safe field-level inverses into `dct_relation_sm`, `dct_replaces_sm`, and `dct_isReplacedBy_sm`
- add materialized-view regression tests for direct, symmetric, and replacement inverse exports

## Root Cause

GEOMG's UI can show inverse relationship widgets from Solr relationship settings, but the Kithe Bridge API was exporting only literal stored array values from `kithe_models.json_attributes`. That meant downstream consumers missed values such as `dct_isReplacedBy_sm` when the replacement was represented by another record's `dct_replaces_sm`.

## Validation

- `bin/rails test test/models/bridge_export_serializer_test.rb test/models/kithe_to_resources_bridge_test.rb`

No Kamal reindex was run.