### PR TITLE
Optimize kithe bridge relationship aggregation

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -704,24 +704,35 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_17_183000) do
               relationship_values.field_name,
               relationship_values.object_id AS related_id
              FROM relationship_values
-          UNION
+          UNION ALL
            SELECT relationship_values.object_id AS document_id,
               'dct_relation_sm'::text AS field_name,
               relationship_values.subject_id AS related_id
              FROM relationship_values
             WHERE (relationship_values.field_name = 'dct_relation_sm'::text)
-          UNION
+          UNION ALL
            SELECT relationship_values.object_id AS document_id,
               'dct_isReplacedBy_sm'::text AS field_name,
               relationship_values.subject_id AS related_id
              FROM relationship_values
             WHERE (relationship_values.field_name = 'dct_replaces_sm'::text)
-          UNION
+          UNION ALL
            SELECT relationship_values.object_id AS document_id,
               'dct_replaces_sm'::text AS field_name,
               relationship_values.subject_id AS related_id
              FROM relationship_values
             WHERE (relationship_values.field_name = 'dct_isReplacedBy_sm'::text)
+          ), relationship_arrays AS (
+           SELECT relationship_exports.document_id,
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_relation_sm'::text)), ARRAY[]::text[]) AS dct_relation_sm,
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'pcdm_memberOf_sm'::text)), ARRAY[]::text[]) AS "pcdm_memberOf_sm",
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_isPartOf_sm'::text)), ARRAY[]::text[]) AS "dct_isPartOf_sm",
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_source_sm'::text)), ARRAY[]::text[]) AS dct_source_sm,
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_isVersionOf_sm'::text)), ARRAY[]::text[]) AS "dct_isVersionOf_sm",
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_replaces_sm'::text)), ARRAY[]::text[]) AS dct_replaces_sm,
+              COALESCE(array_agg(DISTINCT relationship_exports.related_id ORDER BY relationship_exports.related_id) FILTER (WHERE (relationship_exports.field_name = 'dct_isReplacedBy_sm'::text)), ARRAY[]::text[]) AS "dct_isReplacedBy_sm"
+             FROM relationship_exports
+            GROUP BY relationship_exports.document_id
           ), live_documents AS (
            SELECT live_document_ids.bridge_id AS id,
               live_document_ids.title AS dct_title_s,
@@ -822,34 +833,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_17_183000) do
               (live_document_ids.json_attributes ->> 'locn_geometry'::text) AS locn_geometry,
               (live_document_ids.json_attributes ->> 'dcat_bbox'::text) AS dcat_bbox,
               (live_document_ids.json_attributes ->> 'dcat_centroid'::text) AS dcat_centroid,
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_relation_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS dct_relation_sm,
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'pcdm_memberOf_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS "pcdm_memberOf_sm",
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isPartOf_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS "dct_isPartOf_sm",
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_source_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS dct_source_sm,
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isVersionOf_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS "dct_isVersionOf_sm",
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_replaces_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS dct_replaces_sm,
-              ARRAY( SELECT DISTINCT relationship_exports.related_id
-                     FROM relationship_exports
-                    WHERE (((relationship_exports.document_id)::text = (live_document_ids.bridge_id)::text) AND (relationship_exports.field_name = 'dct_isReplacedBy_sm'::text))
-                    ORDER BY relationship_exports.related_id) AS "dct_isReplacedBy_sm",
+              COALESCE(relationship_arrays.dct_relation_sm, ARRAY[]::text[]) AS dct_relation_sm,
+              COALESCE(relationship_arrays."pcdm_memberOf_sm", ARRAY[]::text[]) AS "pcdm_memberOf_sm",
+              COALESCE(relationship_arrays."dct_isPartOf_sm", ARRAY[]::text[]) AS "dct_isPartOf_sm",
+              COALESCE(relationship_arrays.dct_source_sm, ARRAY[]::text[]) AS dct_source_sm,
+              COALESCE(relationship_arrays."dct_isVersionOf_sm", ARRAY[]::text[]) AS "dct_isVersionOf_sm",
+              COALESCE(relationship_arrays.dct_replaces_sm, ARRAY[]::text[]) AS dct_replaces_sm,
+              COALESCE(relationship_arrays."dct_isReplacedBy_sm", ARRAY[]::text[]) AS "dct_isReplacedBy_sm",
               ARRAY( SELECT jsonb_array_elements_text(
                           CASE
                               WHEN (((live_document_ids.json_attributes -> 'dct_rights_sm'::text) IS NULL) OR ((live_document_ids.json_attributes -> 'dct_rights_sm'::text) = 'null'::jsonb)) THEN '[]'::jsonb
@@ -1019,7 +1009,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_17_183000) do
               (live_document_ids.json_attributes ->> 'b1g_websitePlatform_s'::text) AS "b1g_websitePlatform_s",
               false AS deleted,
               NULL::timestamp without time zone AS deleted_at
-             FROM live_document_ids
+             FROM (live_document_ids
+               LEFT JOIN relationship_arrays ON (((relationship_arrays.document_id)::text = (live_document_ids.bridge_id)::text)))
           ), deleted_documents AS (
            SELECT tombstones.friendlier_id AS id,
               tombstones.title AS dct_title_s,

--- a/db/views/kithe_to_resources_bridge_v06.sql
+++ b/db/views/kithe_to_resources_bridge_v06.sql
@@ -36,18 +36,59 @@ relationship_values AS (
 relationship_exports AS (
   SELECT subject_id AS document_id, field_name, object_id AS related_id
   FROM relationship_values
-  UNION
+  UNION ALL
   SELECT object_id AS document_id, 'dct_relation_sm' AS field_name, subject_id AS related_id
   FROM relationship_values
   WHERE field_name = 'dct_relation_sm'
-  UNION
+  UNION ALL
   SELECT object_id AS document_id, 'dct_isReplacedBy_sm' AS field_name, subject_id AS related_id
   FROM relationship_values
   WHERE field_name = 'dct_replaces_sm'
-  UNION
+  UNION ALL
   SELECT object_id AS document_id, 'dct_replaces_sm' AS field_name, subject_id AS related_id
   FROM relationship_values
   WHERE field_name = 'dct_isReplacedBy_sm'
+),
+relationship_arrays AS (
+  SELECT
+    document_id,
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_relation_sm'),
+      ARRAY[]::text[]
+    ) AS dct_relation_sm,
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'pcdm_memberOf_sm'),
+      ARRAY[]::text[]
+    ) AS "pcdm_memberOf_sm",
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_isPartOf_sm'),
+      ARRAY[]::text[]
+    ) AS "dct_isPartOf_sm",
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_source_sm'),
+      ARRAY[]::text[]
+    ) AS dct_source_sm,
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_isVersionOf_sm'),
+      ARRAY[]::text[]
+    ) AS "dct_isVersionOf_sm",
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_replaces_sm'),
+      ARRAY[]::text[]
+    ) AS dct_replaces_sm,
+    COALESCE(
+      array_agg(DISTINCT related_id ORDER BY related_id)
+        FILTER (WHERE field_name = 'dct_isReplacedBy_sm'),
+      ARRAY[]::text[]
+    ) AS "dct_isReplacedBy_sm"
+  FROM relationship_exports
+  GROUP BY document_id
 ),
 live_documents AS (
   SELECT
@@ -87,13 +128,13 @@ live_documents AS (
     json_attributes->>'locn_geometry' AS "locn_geometry",
     json_attributes->>'dcat_bbox' AS "dcat_bbox",
     json_attributes->>'dcat_centroid' AS "dcat_centroid",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_relation_sm' ORDER BY related_id) AS "dct_relation_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'pcdm_memberOf_sm' ORDER BY related_id) AS "pcdm_memberOf_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isPartOf_sm' ORDER BY related_id) AS "dct_isPartOf_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_source_sm' ORDER BY related_id) AS "dct_source_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isVersionOf_sm' ORDER BY related_id) AS "dct_isVersionOf_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_replaces_sm' ORDER BY related_id) AS "dct_replaces_sm",
-    ARRAY(SELECT DISTINCT related_id FROM relationship_exports WHERE document_id = bridge_id AND field_name = 'dct_isReplacedBy_sm' ORDER BY related_id) AS "dct_isReplacedBy_sm",
+    COALESCE(relationship_arrays.dct_relation_sm, ARRAY[]::text[]) AS "dct_relation_sm",
+    COALESCE(relationship_arrays."pcdm_memberOf_sm", ARRAY[]::text[]) AS "pcdm_memberOf_sm",
+    COALESCE(relationship_arrays."dct_isPartOf_sm", ARRAY[]::text[]) AS "dct_isPartOf_sm",
+    COALESCE(relationship_arrays.dct_source_sm, ARRAY[]::text[]) AS "dct_source_sm",
+    COALESCE(relationship_arrays."dct_isVersionOf_sm", ARRAY[]::text[]) AS "dct_isVersionOf_sm",
+    COALESCE(relationship_arrays.dct_replaces_sm, ARRAY[]::text[]) AS "dct_replaces_sm",
+    COALESCE(relationship_arrays."dct_isReplacedBy_sm", ARRAY[]::text[]) AS "dct_isReplacedBy_sm",
     ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_rights_sm' IS NULL OR json_attributes->'dct_rights_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_rights_sm') = 'array' THEN json_attributes->'dct_rights_sm' ELSE jsonb_build_array(json_attributes->'dct_rights_sm') END)) AS "dct_rights_sm",
     ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_rightsHolder_sm' IS NULL OR json_attributes->'dct_rightsHolder_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_rightsHolder_sm') = 'array' THEN json_attributes->'dct_rightsHolder_sm' ELSE jsonb_build_array(json_attributes->'dct_rightsHolder_sm') END)) AS "dct_rightsHolder_sm",
     ARRAY(SELECT jsonb_array_elements_text(CASE WHEN json_attributes->'dct_license_sm' IS NULL OR json_attributes->'dct_license_sm' = 'null'::jsonb THEN '[]'::jsonb WHEN jsonb_typeof(json_attributes->'dct_license_sm') = 'array' THEN json_attributes->'dct_license_sm' ELSE jsonb_build_array(json_attributes->'dct_license_sm') END)) AS "dct_license_sm",
@@ -205,6 +246,8 @@ live_documents AS (
     FALSE AS "deleted",
     NULL::timestamp AS "deleted_at"
   FROM live_document_ids
+  LEFT JOIN relationship_arrays
+    ON relationship_arrays.document_id = live_document_ids.bridge_id
 ),
 deleted_documents AS (
   SELECT


### PR DESCRIPTION
## Summary

This fixes the v06 `kithe_to_resources_bridge` materialized view migration so it no longer rescans the large `relationship_exports` CTE once per relationship field per document.

The view now aggregates relationship arrays once in a `relationship_arrays` CTE and left-joins those arrays back onto live documents. It keeps the existing symmetric relation and replacement inverse behavior, preserves sorted distinct arrays, and returns empty arrays for documents with no relationship values.

## Root Cause

The previous v06 SQL built `relationship_exports`, then used seven correlated `ARRAY(SELECT DISTINCT ...)` subqueries in the live document projection. On the production-sized local snapshot, `EXPLAIN` estimated about 76M relationship export rows and a top-level cost around `1.46e12`, which caused the deploy migration to sit in `CREATE MATERIALIZED VIEW` while holding an exclusive lock on the bridge view.

## Validation

- `EXPLAIN` cost dropped from roughly `1.46e12` to `3.72e7`.
- `bin/rails db:migrate` completed locally in `91.6s` on `108,327` bridge rows and recreated `kithe_to_resources_bridge_id_uidx`.
- Local MV smoke checks passed: row count `108327`, no null relationship arrays.
- `bin/rails test test/models/kithe_to_resources_bridge_test.rb` passed: `3 runs, 13 assertions`.