### PR TITLE
Fix placeheld thumbnail bridge sync

### DIFF
--- a/config/initializers/kithe_bridge_change_capture.rb
+++ b/config/initializers/kithe_bridge_change_capture.rb
@@ -5,7 +5,7 @@
 # The bridge view uses the parent Document's `date_modified_dtsi` (stored in
 # Document.json_attributes) as a "last updated" marker.
 #
-# Some related tables (data dictionaries + entries, downloads) don't update
+# Some related tables (data dictionaries + entries, downloads, assets) don't update
 # the parent Document record themselves. We hook into their callbacks so that
 # changes are reflected in the parent and therefore captured when the MV is
 # refreshed. We also record hard-deleted Documents into a tombstone table so
@@ -20,6 +20,9 @@ module KitheBridgeChangeCapture
     end
     attach_parent_touch_callback!("DocumentDataDictionaryEntry".safe_constantize) do
       document_data_dictionary&.document
+    end
+    attach_parent_touch_callback!("Asset".safe_constantize) do
+      parent
     end
   end
 

--- a/db/migrate/20260618120000_reconcile_placeheld_thumbnail_assets.rb
+++ b/db/migrate/20260618120000_reconcile_placeheld_thumbnail_assets.rb
@@ -1,0 +1,74 @@
+class ReconcilePlaceheldThumbnailAssets < ActiveRecord::Migration[7.2]
+  def up
+    reconciled = 0
+
+    say_with_time "Reconciling placeheld thumbnail states with attached thumbnail assets" do
+      Document.where(id: placeheld_document_ids_with_thumbnail_assets).find_each do |document|
+        next unless document.thumbnail_state_machine.current_state.to_s == "placeheld"
+
+        document.thumbnail_state_machine.transition_to!(
+          :succeeded,
+          {
+            "solr_doc_id" => document.friendlier_id,
+            "source" => "reconcile_placeheld_thumbnail_assets"
+          }
+        )
+
+        touch_document_for_bridge(document)
+        reconciled += 1
+      end
+
+      reconciled
+    end
+
+    refresh_bridge_view if reconciled.positive? && bridge_view_exists?
+  end
+
+  def down
+    # Data reconciliation only. We do not know which records were intentionally
+    # succeeded before this migration, so this is intentionally irreversible.
+  end
+
+  private
+
+  def placeheld_document_ids_with_thumbnail_assets
+    select_values(<<~SQL.squish)
+      SELECT documents.id
+      FROM kithe_models documents
+      JOIN document_thumbnail_transitions transitions
+        ON transitions.kithe_model_id = documents.id
+       AND transitions.most_recent = TRUE
+       AND transitions.to_state = 'placeheld'
+      WHERE documents.type = 'Document'
+        AND EXISTS (
+          SELECT 1
+          FROM kithe_models assets
+          WHERE assets.parent_id = documents.id
+            AND assets.type = 'Asset'
+            AND assets.file_data IS NOT NULL
+            AND assets.json_attributes->>'thumbnail' = 'true'
+        )
+    SQL
+  end
+
+  def bridge_view_exists?
+    select_value("SELECT to_regclass('kithe_to_resources_bridge')::text").present?
+  end
+
+  def touch_document_for_bridge(document)
+    now = Time.current.utc
+    json = document.json_attributes.is_a?(Hash) ? document.json_attributes : {}
+    json["date_modified_dtsi"] = now.iso8601
+
+    document.update_columns(
+      json_attributes: json,
+      updated_at: now
+    )
+  end
+
+  def refresh_bridge_view
+    say_with_time "Refreshing kithe_to_resources_bridge materialized view" do
+      execute "REFRESH MATERIALIZED VIEW kithe_to_resources_bridge"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_17_183000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/test/models/kithe_bridge_change_capture_test.rb
+++ b/test/models/kithe_bridge_change_capture_test.rb
@@ -80,6 +80,9 @@ class KitheBridgeChangeCaptureTest < ActiveSupport::TestCase
 
     assert_equal 1, callback_count(DocumentDataDictionaryEntry._save_callbacks, :kithe_bridge_touch_parent_document)
     assert_equal 1, callback_count(DocumentDataDictionaryEntry._destroy_callbacks, :kithe_bridge_touch_parent_document)
+
+    assert_equal 1, callback_count(Asset._save_callbacks, :kithe_bridge_touch_parent_document)
+    assert_equal 1, callback_count(Asset._destroy_callbacks, :kithe_bridge_touch_parent_document)
   end
 
   private

--- a/test/models/thumbnail_asset_state_test.rb
+++ b/test/models/thumbnail_asset_state_test.rb
@@ -1,0 +1,184 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260618120000_reconcile_placeheld_thumbnail_assets").to_s
+
+class ThumbnailAssetStateTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
+  DOCUMENT_FRIENDLIER_ID = "thumb-placeheld-bridge-test"
+  ASSET_FRIENDLIER_ID = "thumb-placeheld-bridge-test-asset"
+  ORIGINAL_TIME = Time.zone.parse("2025-01-01 00:00:00 UTC")
+  CHANGE_TIME = Time.zone.parse("2026-06-18 17:00:00 UTC")
+
+  setup do
+    cleanup_test_records
+  end
+
+  teardown do
+    cleanup_test_records
+  end
+
+  test "thumbnail asset repairs placeheld state and marks bridge row updated" do
+    document = insert_document
+    asset = insert_asset(document)
+
+    document.thumbnail_state_machine.transition_to!(:processing, {"solr_doc_id" => document.friendlier_id})
+    document.thumbnail_state_machine.transition_to!(:placeheld, {"solr_doc_id" => document.friendlier_id})
+
+    assert_equal "placeheld", document.thumbnail_state_machine.current_state
+
+    refresh_bridge_view
+    assert_in_delta ORIGINAL_TIME.to_f, KitheToResourcesBridge.find(DOCUMENT_FRIENDLIER_ID).kithe_updated_at.to_f, 1
+
+    travel_to CHANGE_TIME do
+      asset.update!(thumbnail: true)
+    end
+
+    document.reload
+    document.instance_variable_set(:@thumbnail_state_machine, nil)
+
+    assert_equal "succeeded", document.thumbnail_state_machine.current_state
+    assert_equal "asset_thumbnail_sync", document.thumbnail_state_machine.last_transition.metadata["source"]
+    assert_equal asset.id, document.thumbnail_state_machine.last_transition.metadata["asset_id"]
+    assert_equal CHANGE_TIME.utc.iso8601, document.json_attributes["date_modified_dtsi"]
+    assert_in_delta CHANGE_TIME.to_f, document.updated_at.to_f, 1
+
+    refresh_bridge_view
+    assert_in_delta CHANGE_TIME.to_f, KitheToResourcesBridge.find(DOCUMENT_FRIENDLIER_ID).kithe_updated_at.to_f, 1
+  end
+
+  test "reconciliation touches repaired documents for bridge sync" do
+    document = insert_document
+    insert_asset(document, thumbnail: true)
+
+    document.thumbnail_state_machine.transition_to!(:processing, {"solr_doc_id" => document.friendlier_id})
+    document.thumbnail_state_machine.transition_to!(:placeheld, {"solr_doc_id" => document.friendlier_id})
+
+    refresh_bridge_view
+    assert_equal "placeheld", document.thumbnail_state_machine.current_state
+    assert_in_delta ORIGINAL_TIME.to_f, KitheToResourcesBridge.find(DOCUMENT_FRIENDLIER_ID).kithe_updated_at.to_f, 1
+
+    travel_to CHANGE_TIME do
+      ActiveRecord::Migration.suppress_messages do
+        ReconcilePlaceheldThumbnailAssets.new.up
+      end
+    end
+
+    document.reload
+    document.instance_variable_set(:@thumbnail_state_machine, nil)
+
+    assert_equal "succeeded", document.thumbnail_state_machine.current_state
+    assert_equal "reconcile_placeheld_thumbnail_assets", document.thumbnail_state_machine.last_transition.metadata["source"]
+    assert_equal CHANGE_TIME.utc.iso8601, document.json_attributes["date_modified_dtsi"]
+    assert_in_delta CHANGE_TIME.to_f, document.updated_at.to_f, 1
+    assert_in_delta CHANGE_TIME.to_f, KitheToResourcesBridge.find(DOCUMENT_FRIENDLIER_ID).kithe_updated_at.to_f, 1
+  end
+
+  private
+
+  def insert_document
+    json_attributes = {
+      "geomg_id_s" => DOCUMENT_FRIENDLIER_ID,
+      "dct_accessRights_s" => "Public",
+      "gbl_resourceClass_sm" => ["Datasets"]
+    }
+
+    connection.execute(<<~SQL.squish)
+      INSERT INTO kithe_models (
+        title,
+        type,
+        json_attributes,
+        created_at,
+        updated_at,
+        friendlier_id,
+        kithe_model_type,
+        publication_state
+      )
+      VALUES (
+        #{connection.quote("Thumbnail Bridge Test")},
+        'Document',
+        #{connection.quote(json_attributes.to_json)}::jsonb,
+        #{connection.quote(ORIGINAL_TIME)},
+        #{connection.quote(ORIGINAL_TIME)},
+        #{connection.quote(DOCUMENT_FRIENDLIER_ID)},
+        1,
+        'published'
+      )
+    SQL
+
+    Document.find_by!(friendlier_id: DOCUMENT_FRIENDLIER_ID)
+  end
+
+  def insert_asset(document, thumbnail: false)
+    json_attributes = {
+      "thumbnail" => thumbnail,
+      "derivative_storage_type" => "public"
+    }
+    file_data = {
+      "id" => "asset/test-thumbnail.png",
+      "storage" => "store",
+      "metadata" => {
+        "filename" => "test-thumbnail.png",
+        "size" => 1234,
+        "mime_type" => "image/png"
+      }
+    }
+
+    connection.execute(<<~SQL.squish)
+      INSERT INTO kithe_models (
+        title,
+        type,
+        position,
+        json_attributes,
+        created_at,
+        updated_at,
+        parent_id,
+        friendlier_id,
+        file_data,
+        kithe_model_type,
+        publication_state
+      )
+      VALUES (
+        #{connection.quote("Thumbnail Asset")},
+        'Asset',
+        1,
+        #{connection.quote(json_attributes.to_json)}::jsonb,
+        #{connection.quote(ORIGINAL_TIME)},
+        #{connection.quote(ORIGINAL_TIME)},
+        #{connection.quote(document.id)},
+        #{connection.quote(ASSET_FRIENDLIER_ID)},
+        #{connection.quote(file_data.to_json)}::jsonb,
+        2,
+        'draft'
+      )
+    SQL
+
+    Asset.find_by!(friendlier_id: ASSET_FRIENDLIER_ID)
+  end
+
+  def cleanup_test_records
+    ids = [DOCUMENT_FRIENDLIER_ID, ASSET_FRIENDLIER_ID].map { |id| connection.quote(id) }.join(", ")
+
+    connection.execute(<<~SQL.squish)
+      DELETE FROM document_thumbnail_transitions
+      WHERE kithe_model_id IN (
+        SELECT id FROM kithe_models WHERE friendlier_id IN (#{ids})
+      )
+    SQL
+    connection.execute("DELETE FROM kithe_models WHERE friendlier_id IN (#{ids})")
+    refresh_bridge_view if bridge_view_exists?
+  end
+
+  def refresh_bridge_view
+    connection.execute("REFRESH MATERIALIZED VIEW kithe_to_resources_bridge")
+  end
+
+  def bridge_view_exists?
+    connection.select_value(<<~SQL.squish)
+      SELECT to_regclass('kithe_to_resources_bridge') IS NOT NULL
+    SQL
+  end
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+end

--- a/vendor/gems/geoblacklight_admin/app/models/asset.rb
+++ b/vendor/gems/geoblacklight_admin/app/models/asset.rb
@@ -31,6 +31,7 @@ class Asset < Kithe::Asset
 
   # After Promotion Callbacks
   after_promotion :set_parent_dct_references_uri
+  after_save :sync_parent_thumbnail_state
 
   def set_parent_dct_references_uri
     GeoblacklightAdmin::SetParentDctReferencesUriJob.perform_later(self) if parent_id.present?
@@ -41,6 +42,24 @@ class Asset < Kithe::Asset
 
   def remove_parent_dct_references_uri
     GeoblacklightAdmin::RemoveParentDctReferencesUriJob.perform_later(self) if parent_id.present?
+  end
+
+  def sync_parent_thumbnail_state
+    return unless thumbnail?
+    return if file_data.blank?
+    return unless parent.present?
+
+    state_machine = parent.thumbnail_state_machine
+    return unless state_machine.current_state.to_s == "placeheld"
+
+    state_machine.transition_to!(
+      :succeeded,
+      {
+        "solr_doc_id" => parent.friendlier_id,
+        "asset_id" => id,
+        "source" => "asset_thumbnail_sync"
+      }
+    )
   end
 
   # After Commit Callbacks

--- a/vendor/gems/geoblacklight_admin/app/models/document_thumbnail_state_machine.rb
+++ b/vendor/gems/geoblacklight_admin/app/models/document_thumbnail_state_machine.rb
@@ -16,7 +16,7 @@ class DocumentThumbnailStateMachine
   transition from: :initialized, to: %i[queued processing]
   transition from: :queued, to: %i[queued processing]
   transition from: :processing, to: %i[queued processing placeheld succeeded failed]
-  transition from: :placeheld, to: %i[queued processing failed]
+  transition from: :placeheld, to: %i[queued processing succeeded failed]
   transition from: :failed, to: %i[queued processing]
   transition from: :succeeded, to: %i[queued processing]
 end


### PR DESCRIPTION
## Summary

Fixes thumbnail records that have a real attached thumbnail asset but remain stuck in the `placeheld` thumbnail state.

## What Changed

- Allows thumbnail state to move from `placeheld` to `succeeded` when a real thumbnail asset is attached.
- Adds an asset-save callback that repairs a parent document's stale `placeheld` state when the saved asset is marked as a thumbnail and has file data.
- Touches parent documents when assets change so `kithe_to_resources_bridge.kithe_updated_at` advances for incremental sync.
- Adds a migration to reconcile existing attached/placeheld records, touch each impacted parent document, and refresh the bridge materialized view.
- Adds focused regression tests for future asset saves and deploy-time reconciliation.

## Root Cause

Thumbnail automation could transition a document to `placeheld`, and later manual/asset thumbnail attachment made `thumbnail` true without moving the thumbnail state back to `succeeded`. Asset changes also did not touch the parent document, so the Kithe bridge incremental API could miss those resource updates until another parent-level change occurred.

## Validation

Ran:

```sh
bin/rails test test/models/thumbnail_asset_state_test.rb test/models/kithe_bridge_change_capture_test.rb test/models/kithe_to_resources_bridge_test.rb test/models/bridge_export_serializer_test.rb vendor/gems/geoblacklight_admin/test/models/document_thumbnail_state_machine_test.rb
```

Result: `10 runs, 52 assertions, 0 failures, 0 errors`.